### PR TITLE
feat: add reporting service and reports page

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -4,6 +4,7 @@ from app.api.subgroups import router as subgroups_router
 from app.api.accounts import router as accounts_router
 from app.api.tenants import router as tenants_router
 from app.api.users import router as users_router
+from app.api.reports import router as reports_router
 
 def include_routers(app):
     app.include_router(auth_router)
@@ -12,3 +13,4 @@ def include_routers(app):
     app.include_router(groups_router)
     app.include_router(subgroups_router)
     app.include_router(accounts_router)
+    app.include_router(reports_router)

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter, Depends
+from app.services.reporting import cash_flow_summary
+from app.services.dependencies import get_current_active_user
+
+router = APIRouter(prefix="/reports", tags=["reports"])
+
+@router.get("/cash-flow")
+async def cash_flow(group_by: str = "month", current=Depends(get_current_active_user)):
+    return await cash_flow_summary(group_by)

--- a/backend/app/services/reporting.py
+++ b/backend/app/services/reporting.py
@@ -1,0 +1,27 @@
+from typing import Literal, List, Dict
+from app.db.bq_client import PROJECT_ID, DATASET, client
+
+CASH_FLOW_TABLE = "CashFlow"
+
+async def cash_flow_summary(group_by: Literal["month", "day"] = "month") -> List[Dict]:
+    """Aggregate cash flow data from BigQuery.
+
+    Args:
+        group_by: "month" or "day" defining the aggregation granularity.
+
+    Returns:
+        List of dictionaries with period, predicted and realized totals.
+    """
+    group_expr = "DATE(date)" if group_by == "day" else "FORMAT_DATE('%Y-%m', DATE(date))"
+    table = f"`{PROJECT_ID}.{DATASET}.{CASH_FLOW_TABLE}`"
+    sql = f"""
+        SELECT {group_expr} AS period,
+               SUM(predicted) AS predicted,
+               SUM(realized) AS realized
+        FROM {table}
+        GROUP BY period
+        ORDER BY period
+    """
+    job = client.query(sql)
+    rows = job.result()
+    return [dict(row) for row in rows]

--- a/frontend/pages/reports.tsx
+++ b/frontend/pages/reports.tsx
@@ -1,0 +1,57 @@
+import React, { useContext, useEffect, useState } from 'react';
+import Layout from '../components/layout/Layout';
+import Card from '../components/ui/Card';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { AuthContext } from '../context/AuthContext';
+import { getCashFlowReport } from '../services/api';
+
+interface ReportItem {
+  period: string;
+  predicted: number;
+  realized: number;
+}
+
+export default function Reports() {
+  const { token } = useContext(AuthContext);
+  const [data, setData] = useState<ReportItem[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const results = await getCashFlowReport('month', token || undefined);
+        setData(results);
+      } catch (error) {
+        console.error('Failed to fetch report', error);
+      }
+    };
+    if (token) {
+      fetchData();
+    }
+  }, [token]);
+
+  return (
+    <Layout title="Relatórios">
+      <div className="space-y-6">
+        <Card>
+          <Card.Header>
+            <h2 className="text-xl font-semibold">Previsto x Realizado</h2>
+          </Card.Header>
+          <Card.Body>
+            <div className="w-full h-96">
+              <ResponsiveContainer>
+                <BarChart data={data}>
+                  <XAxis dataKey="period" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="predicted" fill="#3B82F6" name="Previsto" />
+                  <Bar dataKey="realized" fill="#10B981" name="Realizado" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </Card.Body>
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -15,4 +15,13 @@ export const signup = async (data: any, token?: string) => {
   return response.data;
 };
 
+export const getCashFlowReport = async (groupBy: string = 'month', token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.get('/reports/cash-flow', {
+    params: { group_by: groupBy },
+    headers,
+  });
+  return response.data;
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- add reporting service with BigQuery aggregation
- expose `/reports/cash-flow` endpoint returning predicted vs realized
- create reports page with chart consuming new API

## Testing
- `pytest`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aef28c21608323b02724f4d34e1854