### PR TITLE
Add CRUD endpoints for finance subgroups and accounts

### DIFF
--- a/backend/app/api/accounts.py
+++ b/backend/app/api/accounts.py
@@ -1,1 +1,71 @@
-...
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.db.bq_client import delete, insert, query, update
+from app.models.finance import AccountCreate, AccountInDB
+from app.services.dependencies import get_current_user, tenant
+
+
+router = APIRouter(prefix="/accounts", tags=["accounts"])
+
+
+@router.get("/", response_model=list[AccountInDB])
+async def list_accounts(
+    current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    return await query("Accounts", {"tenant_id": tenant_id})
+
+
+@router.post("/", response_model=AccountInDB, status_code=201)
+async def create_account(
+    account: AccountCreate, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    if account.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    new_id = str(uuid4())
+    record = account.dict()
+    record["id"] = new_id
+    await insert("Accounts", record)
+    return record
+
+
+@router.get("/{account_id}", response_model=AccountInDB)
+async def get_account(
+    account_id: str, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    res = await query("Accounts", {"id": account_id, "tenant_id": tenant_id})
+    if not res:
+        raise HTTPException(status_code=404, detail="Account not found")
+    return res[0]
+
+
+@router.put("/{account_id}", response_model=AccountInDB)
+async def update_account(
+    account_id: str,
+    account: AccountCreate,
+    current=Depends(get_current_user),
+    tenant_id: str = Depends(tenant),
+):
+    if account.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    existing = await query("Accounts", {"id": account_id, "tenant_id": tenant_id})
+    if not existing:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    await update("Accounts", account_id, account.dict())
+    return {**existing[0], **account.dict(), "id": account_id}
+
+
+@router.delete("/{account_id}", status_code=204)
+async def delete_account(
+    account_id: str, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    existing = await query("Accounts", {"id": account_id, "tenant_id": tenant_id})
+    if not existing:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    await delete("Accounts", account_id)
+

--- a/backend/app/api/subgroups.py
+++ b/backend/app/api/subgroups.py
@@ -1,1 +1,71 @@
-...
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.db.bq_client import delete, insert, query, update
+from app.models.finance import SubgroupCreate, SubgroupInDB
+from app.services.dependencies import get_current_user, tenant
+
+
+router = APIRouter(prefix="/subgroups", tags=["subgroups"])
+
+
+@router.get("/", response_model=list[SubgroupInDB])
+async def list_subgroups(
+    current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    return await query("Subgroups", {"tenant_id": tenant_id})
+
+
+@router.post("/", response_model=SubgroupInDB, status_code=201)
+async def create_subgroup(
+    subgroup: SubgroupCreate, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    if subgroup.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    new_id = str(uuid4())
+    record = subgroup.dict()
+    record["id"] = new_id
+    await insert("Subgroups", record)
+    return record
+
+
+@router.get("/{subgroup_id}", response_model=SubgroupInDB)
+async def get_subgroup(
+    subgroup_id: str, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    res = await query("Subgroups", {"id": subgroup_id, "tenant_id": tenant_id})
+    if not res:
+        raise HTTPException(status_code=404, detail="Subgroup not found")
+    return res[0]
+
+
+@router.put("/{subgroup_id}", response_model=SubgroupInDB)
+async def update_subgroup(
+    subgroup_id: str,
+    subgroup: SubgroupCreate,
+    current=Depends(get_current_user),
+    tenant_id: str = Depends(tenant),
+):
+    if subgroup.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    existing = await query("Subgroups", {"id": subgroup_id, "tenant_id": tenant_id})
+    if not existing:
+        raise HTTPException(status_code=404, detail="Subgroup not found")
+
+    await update("Subgroups", subgroup_id, subgroup.dict())
+    return {**existing[0], **subgroup.dict(), "id": subgroup_id}
+
+
+@router.delete("/{subgroup_id}", status_code=204)
+async def delete_subgroup(
+    subgroup_id: str, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    existing = await query("Subgroups", {"id": subgroup_id, "tenant_id": tenant_id})
+    if not existing:
+        raise HTTPException(status_code=404, detail="Subgroup not found")
+
+    await delete("Subgroups", subgroup_id)
+

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,7 @@
-from pydantic import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:  # pragma: no cover - fallback for pydantic v1
+    from pydantic import BaseSettings
 
 class Settings(BaseSettings):
     JWT_SECRET: str

--- a/backend/app/services/dependencies.py
+++ b/backend/app/services/dependencies.py
@@ -26,3 +26,22 @@ def require_tenant_access(tenant_id: str, current: UserInDB = Depends(get_curren
     if current.role == Role.tenant_user and current.tenant_id != tenant_id:
         raise HTTPException(status_code=403, detail="Access denied to this tenant")
     return current
+
+
+def tenant(tenant_id: str | None = None, current: UserInDB = Depends(get_current_user)) -> str:
+    """Validate and return the tenant identifier for the request.
+
+    If ``tenant_id`` is not provided, the current user's tenant is used. Tenant
+    users are restricted to their own tenant and will receive a 403 error when
+    trying to access others.
+    """
+
+    if tenant_id is None:
+        if current.tenant_id is None:
+            raise HTTPException(status_code=400, detail="tenant_id required")
+        tenant_id = current.tenant_id
+
+    if current.role == Role.tenant_user and current.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    return tenant_id

--- a/backend/tests/test_finance_api.py
+++ b/backend/tests/test_finance_api.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+# Stub Google BigQuery client before importing application modules to avoid
+# external dependencies during tests.
+fake_bigquery = types.SimpleNamespace(
+    Client=lambda *a, **k: None,
+    ScalarQueryParameter=lambda *a, **k: None,
+    QueryJobConfig=lambda *a, **k: None,
+)
+google_cloud = types.SimpleNamespace(bigquery=fake_bigquery)
+sys.modules.setdefault("google", types.ModuleType("google"))
+sys.modules["google.cloud"] = google_cloud
+sys.modules["google.cloud.bigquery"] = fake_bigquery
+
+# Ensure the "backend" directory is on the Python path so ``app`` can be imported
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+# Provide required configuration variables for Settings
+os.environ.setdefault("JWT_SECRET", "testing-secret")
+
+from app.main import app  # noqa: E402
+from app.models.user import Role, UserInDB  # noqa: E402
+from app.services.dependencies import get_current_user  # noqa: E402
+
+
+def override_tenant_user():
+    return UserInDB(
+        id="u1",
+        username="tenant",
+        email="t@example.com",
+        hashed_password="",
+        role=Role.tenant_user,
+        tenant_id="t1",
+    )
+
+
+client = TestClient(app)
+
+
+def test_subgroup_creation_forbidden_for_other_tenant():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.post(
+        "/subgroups/?tenant_id=t2",
+        json={"group_id": "g1", "name": "s1", "tenant_id": "t2"},
+    )
+    assert response.status_code == 403
+    app.dependency_overrides.clear()
+
+
+def test_account_delete_forbidden_for_other_tenant():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.delete("/accounts/a1?tenant_id=t2")
+    assert response.status_code == 403
+    app.dependency_overrides.clear()
+
+
+def test_account_creation_validation_error():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.post(
+        "/accounts/?tenant_id=t1",
+        json={"subgroup_id": "s1", "balance": 10.0, "tenant_id": "t1"},
+    )
+    assert response.status_code == 422
+    app.dependency_overrides.clear()
+


### PR DESCRIPTION
## Summary
- implement full CRUD for subgroups and accounts using tenant-aware auth
- add tenant dependency and pydantic settings fallback
- test permissions and validation for finance endpoints

## Testing
- `pytest backend/tests/test_finance_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef2899fe08323b1ff9eaab251b808