### PR TITLE
Ensure tenant access checks before deleting

### DIFF
--- a/backend/app/api/forecast.py
+++ b/backend/app/api/forecast.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends, HTTPException
+from app.db.bq_client import delete, query
+from app.services.dependencies import get_current_active_user, require_tenant_access
+
+router = APIRouter(prefix="/forecast", tags=["forecast"])
+
+@router.delete("/{forecast_id}", status_code=204)
+async def delete_forecast(forecast_id: str, current=Depends(get_current_active_user)):
+    records = await query("Forecasts", {"id": forecast_id})
+    if not records:
+        raise HTTPException(status_code=404, detail="Forecast not found")
+    record = records[0]
+    require_tenant_access(record["tenant_id"], current)
+    await delete("Forecasts", forecast_id)

--- a/backend/app/api/transactions.py
+++ b/backend/app/api/transactions.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, Depends, HTTPException
+from app.db.bq_client import delete, query
+from app.services.dependencies import get_current_active_user, require_tenant_access
+
+router = APIRouter(prefix="/transactions", tags=["transactions"])
+
+@router.delete("/{transaction_id}", status_code=204)
+async def delete_transaction(transaction_id: str, current=Depends(get_current_active_user)):
+    records = await query("Transactions", {"id": transaction_id})
+    if not records:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+    record = records[0]
+    require_tenant_access(record["tenant_id"], current)
+    await delete("Transactions", transaction_id)


### PR DESCRIPTION
## Summary
- add transaction delete endpoint with tenant access validation
- add forecast delete endpoint with tenant access validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af522711f48323b9c1c58c96045157