### PR TITLE
Use native date types in finance models

### DIFF
--- a/backend/app/models/finance.py
+++ b/backend/app/models/finance.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from datetime import date, datetime
+from pydantic import BaseModel, Field, field_serializer
 from typing import Optional
 
 class GroupCreate(BaseModel):
@@ -29,3 +30,45 @@ class AccountCreate(BaseModel):
 class AccountInDB(AccountCreate):
     id: str
     created_at: str
+
+
+class TransactionCreate(BaseModel):
+    account_id: str
+    amount: float
+    date: date
+    description: Optional[str] = None
+    tenant_id: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    @field_serializer("date", when_used="json")
+    def serialize_date(self, v: date) -> str:
+        return v.isoformat()
+
+    @field_serializer("created_at", when_used="json")
+    def serialize_created_at(self, v: datetime) -> str:
+        return v.isoformat()
+
+
+class TransactionInDB(TransactionCreate):
+    id: str
+
+
+class ForecastCreate(BaseModel):
+    account_id: str
+    amount: float
+    expected_date: date
+    description: Optional[str] = None
+    tenant_id: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    @field_serializer("expected_date", when_used="json")
+    def serialize_expected_date(self, v: date) -> str:
+        return v.isoformat()
+
+    @field_serializer("created_at", when_used="json")
+    def serialize_created_at(self, v: datetime) -> str:
+        return v.isoformat()
+
+
+class ForecastInDB(ForecastCreate):
+    id: str

--- a/backend/tests/test_date_serialization.py
+++ b/backend/tests/test_date_serialization.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.models.finance import TransactionCreate, ForecastCreate
+
+
+def test_transaction_date_parsing_and_serialization():
+    data = {
+        "account_id": "acc1",
+        "amount": 10.5,
+        "date": "2024-05-20",
+        "tenant_id": "tenant1",
+        "created_at": "2024-05-01T12:30:45",
+    }
+    tx = TransactionCreate(**data)
+    assert tx.date.year == 2024
+    assert tx.created_at.year == 2024
+    dumped = tx.model_dump(mode="json")
+    assert dumped["date"] == "2024-05-20"
+    assert dumped["created_at"].startswith("2024-05-01T12:30:45")
+
+
+def test_forecast_date_parsing_and_serialization():
+    data = {
+        "account_id": "acc1",
+        "amount": 20.0,
+        "expected_date": "2024-06-15",
+        "tenant_id": "tenant1",
+        "created_at": "2024-06-01T08:00:00",
+    }
+    fc = ForecastCreate(**data)
+    assert fc.expected_date.month == 6
+    assert fc.created_at.hour == 8
+    dumped = fc.model_dump(mode="json")
+    assert dumped["expected_date"] == "2024-06-15"
+    assert dumped["created_at"].startswith("2024-06-01T08:00:00")
+
+
+def test_invalid_transaction_date():
+    data = {
+        "account_id": "acc1",
+        "amount": 10.5,
+        "date": "invalid-date",
+        "tenant_id": "tenant1",
+        "created_at": "2024-05-01T12:30:45",
+    }
+    with pytest.raises(ValueError):
+        TransactionCreate(**data)


### PR DESCRIPTION
## Summary
- add TransactionCreate and ForecastCreate models with `date` and `expected_date` typed as `datetime.date`
- serialize `created_at` fields as `datetime.datetime`
- test parsing and JSON serialization of date fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af522966c88323bc030dd139bf0c45