### PR TITLE
Refactor group creation to split dict creation and ID assignment

### DIFF
--- a/backend/app/api/groups.py
+++ b/backend/app/api/groups.py
@@ -15,6 +15,7 @@ async def list_groups(current=Depends(get_current_active_user)):
 @router.post("/", response_model=GroupInDB, status_code=201)
 async def create_group(group: GroupCreate, current=Depends(require_super_admin)):
     gid = str(uuid4())
-    rec = group.dict(); rec["id"] = gid
+    rec = group.dict()
+    rec["id"] = gid
     await insert("Groups", rec)
     return rec


### PR DESCRIPTION
## Summary
- split dict creation and ID assignment into separate lines in group creation endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5229ab4c83238cb01280b068cc78