### PR TITLE
Add cash flow reporting service with tests

### DIFF
--- a/backend/app/services/reporting.py
+++ b/backend/app/services/reporting.py
@@ -1,27 +1,46 @@
-from typing import Literal, List, Dict
-from app.db.bq_client import PROJECT_ID, DATASET, client
+"""Utilities for reporting related queries."""
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, List
+
+from app.db.bq_client import query
 
 CASH_FLOW_TABLE = "CashFlow"
 
-async def cash_flow_summary(group_by: Literal["month", "day"] = "month") -> List[Dict]:
-    """Aggregate cash flow data from BigQuery.
+
+async def cash_flow_summary(group_by: str) -> Any:
+    """Return cash-flow aggregates grouped by the provided period.
+
+    The function fetches cash-flow records from the database and groups them
+    by either ``month`` or ``day``. Each group contains the sum of the
+    ``predicted`` and ``realized`` values.
 
     Args:
-        group_by: "month" or "day" defining the aggregation granularity.
+        group_by: ``"month"`` or ``"day"`` defining aggregation granularity.
 
     Returns:
-        List of dictionaries with period, predicted and realized totals.
+        A list of dictionaries with ``period``, ``predicted`` and ``realized``
+        totals ordered by the period.
     """
-    group_expr = "DATE(date)" if group_by == "day" else "FORMAT_DATE('%Y-%m', DATE(date))"
-    table = f"`{PROJECT_ID}.{DATASET}.{CASH_FLOW_TABLE}`"
-    sql = f"""
-        SELECT {group_expr} AS period,
-               SUM(predicted) AS predicted,
-               SUM(realized) AS realized
-        FROM {table}
-        GROUP BY period
-        ORDER BY period
-    """
-    job = client.query(sql)
-    rows = job.result()
-    return [dict(row) for row in rows]
+
+    rows = await query(CASH_FLOW_TABLE, {})
+
+    totals: Dict[str, Dict[str, float]] = defaultdict(lambda: {"predicted": 0.0, "realized": 0.0})
+
+    for row in rows:
+        dt = datetime.fromisoformat(str(row["date"]))
+        if group_by == "day":
+            key = dt.strftime("%Y-%m-%d")
+        elif group_by == "month":
+            key = dt.strftime("%Y-%m")
+        else:
+            raise ValueError("group_by must be 'month' or 'day'")
+
+        totals[key]["predicted"] += float(row.get("predicted", 0))
+        totals[key]["realized"] += float(row.get("realized", 0))
+
+    return [
+        {"period": period, **values}
+        for period, values in sorted(totals.items())
+    ]

--- a/backend/tests/test_reporting.py
+++ b/backend/tests/test_reporting.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+import asyncio
+import importlib
+import types
+
+# Add backend directory to sys.path to import app package
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def _load_service_with_query(sample):
+    async def fake_query(table, filters):
+        return sample
+
+    fake_module = types.SimpleNamespace(query=fake_query)
+    sys.modules["app.db.bq_client"] = fake_module
+
+    module = importlib.reload(importlib.import_module("app.services.reporting"))
+    return module.cash_flow_summary
+
+
+def test_cash_flow_summary_group_by_month():
+    sample = [
+        {"date": "2025-01-01", "predicted": 100, "realized": 90},
+        {"date": "2025-01-15", "predicted": 200, "realized": 180},
+        {"date": "2025-02-01", "predicted": 150, "realized": 120},
+    ]
+
+    cash_flow_summary = _load_service_with_query(sample)
+    result = asyncio.run(cash_flow_summary("month"))
+    assert result == [
+        {"period": "2025-01", "predicted": 300.0, "realized": 270.0},
+        {"period": "2025-02", "predicted": 150.0, "realized": 120.0},
+    ]
+
+
+def test_cash_flow_summary_group_by_day():
+    sample = [
+        {"date": "2025-01-01", "predicted": 100, "realized": 90},
+        {"date": "2025-01-15", "predicted": 200, "realized": 180},
+        {"date": "2025-02-01", "predicted": 150, "realized": 120},
+    ]
+
+    cash_flow_summary = _load_service_with_query(sample)
+    result = asyncio.run(cash_flow_summary("day"))
+    assert result == [
+        {"period": "2025-01-01", "predicted": 100.0, "realized": 90.0},
+        {"period": "2025-01-15", "predicted": 200.0, "realized": 180.0},
+        {"period": "2025-02-01", "predicted": 150.0, "realized": 120.0},
+    ]


### PR DESCRIPTION
## Summary
- implement `cash_flow_summary` to aggregate predicted and realized amounts by month or day
- add unit tests verifying monthly and daily grouping using stubbed database queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5206b29083239b8f6b94bccbea9f