### PR TITLE
Use Decimal and datetime for finance models

### DIFF
--- a/backend/app/api/accounts.py
+++ b/backend/app/api/accounts.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+from decimal import Decimal
+
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.db.bq_client import delete, insert, query, update
@@ -27,6 +29,7 @@ async def create_account(
     new_id = str(uuid4())
     record = account.dict()
     record["id"] = new_id
+    record["balance"] = Decimal("0")
     await insert("Accounts", record)
     return record
 

--- a/backend/app/models/finance.py
+++ b/backend/app/models/finance.py
@@ -1,5 +1,8 @@
-from pydantic import BaseModel
+from datetime import datetime
+from decimal import Decimal
 from typing import Optional
+
+from pydantic import BaseModel
 
 class GroupCreate(BaseModel):
     name: str
@@ -8,7 +11,7 @@ class GroupCreate(BaseModel):
 
 class GroupInDB(GroupCreate):
     id: str
-    created_at: str
+    created_at: datetime
 
 class SubgroupCreate(BaseModel):
     group_id: str
@@ -18,14 +21,14 @@ class SubgroupCreate(BaseModel):
 
 class SubgroupInDB(SubgroupCreate):
     id: str
-    created_at: str
+    created_at: datetime
 
 class AccountCreate(BaseModel):
     subgroup_id: str
     name: str
-    balance: float
+    balance: Decimal
     tenant_id: str
 
 class AccountInDB(AccountCreate):
     id: str
-    created_at: str
+    created_at: datetime


### PR DESCRIPTION
## Summary
- use Decimal for account balances and datetime for timestamps
- initialize new accounts with balance 0

## Testing
- `python3 -m pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_68af56f426588323a3417be07043ce86