### PR TITLE
Add BigQuery bulk insert helper and tests for account import

### DIFF
--- a/backend/app/db/bq_client.py
+++ b/backend/app/db/bq_client.py
@@ -30,6 +30,17 @@ async def insert(table: str, row: Dict[str, Any]):
     if errors:
         raise RuntimeError(f"Error inserting into {table}: {errors}")
 
+async def insert_many(table: str, rows: List[Dict[str, Any]]):
+    """Insert multiple JSON rows into the specified table.
+
+    Raises:
+        RuntimeError: If BigQuery reports any insertion errors.
+    """
+    table_ref = f"{PROJECT_ID}.{DATASET}.{table}"
+    errors = client.insert_rows_json(table_ref, rows)
+    if errors:
+        raise RuntimeError(f"Error inserting into {table}: {errors}")
+
 async def update(table: str, id: str, data: Dict[str, Any]):
     # Atualiza uma linha por id na tabela especificada.
     set_clause = ", ".join([f"{k}=@{k}" for k in data.keys()])

--- a/backend/tests/test_account_import.py
+++ b/backend/tests/test_account_import.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+
+class DummyClient:
+    def insert_rows_json(self, table, rows):
+        return []
+
+
+fake_bigquery = types.SimpleNamespace(
+    Client=lambda *a, **k: DummyClient(),
+    ScalarQueryParameter=lambda *a, **k: None,
+    QueryJobConfig=lambda *a, **k: None,
+)
+google_cloud = types.SimpleNamespace(bigquery=fake_bigquery)
+sys.modules.setdefault("google", types.ModuleType("google"))
+sys.modules["google.cloud"] = google_cloud
+sys.modules["google.cloud.bigquery"] = fake_bigquery
+
+# Ensure the "backend" directory is on the Python path so ``app`` can be imported
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+# Provide required configuration variables for Settings
+os.environ.setdefault("JWT_SECRET", "testing-secret")
+
+from app.main import app  # noqa: E402
+from app.models.user import Role, UserInDB  # noqa: E402
+from app.services.dependencies import get_current_user  # noqa: E402
+from app.db import bq_client  # noqa: E402
+
+
+def override_tenant_user():
+    return UserInDB(
+        id="u1",
+        username="tenant",
+        email="t@example.com",
+        hashed_password="",
+        role=Role.tenant_user,
+        tenant_id="t1",
+    )
+
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_import_accounts_failure(monkeypatch):
+    app.dependency_overrides[get_current_user] = override_tenant_user
+
+    def failing_insert_rows_json(table, rows):
+        return [{"error": "bad"}]
+
+    monkeypatch.setattr(bq_client.client, "insert_rows_json", failing_insert_rows_json)
+
+    payload = [
+        {"subgroup_id": "sg1", "name": "acc1", "balance": 0, "tenant_id": "t1"}
+    ]
+
+    response = client.post("/accounts/import?tenant_id=t1", json=payload)
+    assert response.status_code == 500
+
+    app.dependency_overrides.clear()
+
+
+def test_import_accounts_success():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+
+    payload = [
+        {"subgroup_id": "sg1", "name": "acc1", "balance": 0, "tenant_id": "t1"}
+    ]
+
+    response = client.post("/accounts/import?tenant_id=t1", json=payload)
+    assert response.status_code == 201
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add `insert_many` helper for BigQuery JSON bulk inserts
- use helper in `/accounts/import` endpoint and ensure created_at is set
- test account import success and surface failures from BigQuery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5946001c8323aadd7312211320d4