### PR TITLE
feat: filter cash flow reports by tenant

### DIFF
--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -1,9 +1,13 @@
 from fastapi import APIRouter, Depends
 from app.services.reporting import cash_flow_summary
-from app.services.dependencies import get_current_active_user
+from app.services.dependencies import get_current_active_user, tenant
 
 router = APIRouter(prefix="/reports", tags=["reports"])
 
 @router.get("/cash-flow")
-async def cash_flow(group_by: str = "month", current=Depends(get_current_active_user)):
-    return await cash_flow_summary(group_by)
+async def cash_flow(
+    group_by: str = "month",
+    tenant_id: str = Depends(tenant),
+    current=Depends(get_current_active_user),
+):
+    return await cash_flow_summary(group_by, tenant_id)

--- a/backend/app/services/reporting.py
+++ b/backend/app/services/reporting.py
@@ -9,7 +9,7 @@ from app.db.bq_client import query
 CASH_FLOW_TABLE = "CashFlow"
 
 
-async def cash_flow_summary(group_by: str) -> Any:
+async def cash_flow_summary(group_by: str, tenant_id: str) -> Any:
     """Return cash-flow aggregates grouped by the provided period.
 
     The function fetches cash-flow records from the database and groups them
@@ -18,13 +18,14 @@ async def cash_flow_summary(group_by: str) -> Any:
 
     Args:
         group_by: ``"month"`` or ``"day"`` defining aggregation granularity.
+        tenant_id: Identifier used to filter results by tenant.
 
     Returns:
         A list of dictionaries with ``period``, ``predicted`` and ``realized``
         totals ordered by the period.
     """
 
-    rows = await query(CASH_FLOW_TABLE, {})
+    rows = await query(CASH_FLOW_TABLE, {"tenant_id": tenant_id})
 
     totals: Dict[str, Dict[str, float]] = defaultdict(lambda: {"predicted": 0.0, "realized": 0.0})
 

--- a/backend/tests/test_reporting.py
+++ b/backend/tests/test_reporting.py
@@ -10,25 +10,31 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
 def _load_service_with_query(sample):
+    recorded = {}
+
     async def fake_query(table, filters):
-        return sample
+        recorded["filters"] = filters
+        tenant_id = filters.get("tenant_id")
+        return [row for row in sample if row.get("tenant_id") == tenant_id]
 
     fake_module = types.SimpleNamespace(query=fake_query)
     sys.modules["app.db.bq_client"] = fake_module
 
     module = importlib.reload(importlib.import_module("app.services.reporting"))
-    return module.cash_flow_summary
+    return module.cash_flow_summary, recorded
 
 
 def test_cash_flow_summary_group_by_month():
     sample = [
-        {"date": "2025-01-01", "predicted": 100, "realized": 90},
-        {"date": "2025-01-15", "predicted": 200, "realized": 180},
-        {"date": "2025-02-01", "predicted": 150, "realized": 120},
+        {"date": "2025-01-01", "predicted": 100, "realized": 90, "tenant_id": "t1"},
+        {"date": "2025-01-15", "predicted": 200, "realized": 180, "tenant_id": "t1"},
+        {"date": "2025-02-01", "predicted": 150, "realized": 120, "tenant_id": "t1"},
+        {"date": "2025-03-01", "predicted": 300, "realized": 250, "tenant_id": "t2"},
     ]
 
-    cash_flow_summary = _load_service_with_query(sample)
-    result = asyncio.run(cash_flow_summary("month"))
+    cash_flow_summary, recorded = _load_service_with_query(sample)
+    result = asyncio.run(cash_flow_summary("month", "t1"))
+    assert recorded["filters"] == {"tenant_id": "t1"}
     assert result == [
         {"period": "2025-01", "predicted": 300.0, "realized": 270.0},
         {"period": "2025-02", "predicted": 150.0, "realized": 120.0},
@@ -37,15 +43,31 @@ def test_cash_flow_summary_group_by_month():
 
 def test_cash_flow_summary_group_by_day():
     sample = [
-        {"date": "2025-01-01", "predicted": 100, "realized": 90},
-        {"date": "2025-01-15", "predicted": 200, "realized": 180},
-        {"date": "2025-02-01", "predicted": 150, "realized": 120},
+        {"date": "2025-01-01", "predicted": 100, "realized": 90, "tenant_id": "t1"},
+        {"date": "2025-01-15", "predicted": 200, "realized": 180, "tenant_id": "t1"},
+        {"date": "2025-02-01", "predicted": 150, "realized": 120, "tenant_id": "t1"},
+        {"date": "2025-03-01", "predicted": 300, "realized": 250, "tenant_id": "t2"},
     ]
 
-    cash_flow_summary = _load_service_with_query(sample)
-    result = asyncio.run(cash_flow_summary("day"))
+    cash_flow_summary, recorded = _load_service_with_query(sample)
+    result = asyncio.run(cash_flow_summary("day", "t1"))
+    assert recorded["filters"] == {"tenant_id": "t1"}
     assert result == [
         {"period": "2025-01-01", "predicted": 100.0, "realized": 90.0},
         {"period": "2025-01-15", "predicted": 200.0, "realized": 180.0},
         {"period": "2025-02-01", "predicted": 150.0, "realized": 120.0},
+    ]
+
+
+def test_cash_flow_summary_isolates_tenant():
+    sample = [
+        {"date": "2025-01-01", "predicted": 100, "realized": 90, "tenant_id": "t1"},
+        {"date": "2025-01-01", "predicted": 50, "realized": 40, "tenant_id": "t2"},
+    ]
+
+    cash_flow_summary, recorded = _load_service_with_query(sample)
+    result = asyncio.run(cash_flow_summary("day", "t2"))
+    assert recorded["filters"] == {"tenant_id": "t2"}
+    assert result == [
+        {"period": "2025-01-01", "predicted": 50.0, "realized": 40.0},
     ]


### PR DESCRIPTION
## Summary
- pass tenant id through reporting API
- scope cash flow queries to tenant
- test cash flow summary tenant isolation

## Testing
- `pytest backend/tests/test_reporting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af64c903148323807604215e9ac7b4