### PR TITLE
Add transaction and forecast endpoints with models and tests

### DIFF
--- a/backend/app/api/forecast.py
+++ b/backend/app/api/forecast.py
@@ -1,14 +1,69 @@
+"""API routes for forecast operations."""
+
+from datetime import datetime
+from uuid import uuid4
+
 from fastapi import APIRouter, Depends, HTTPException
-from app.db.bq_client import delete, query
-from app.services.dependencies import get_current_active_user, require_tenant_access
+
+from app.db.bq_client import delete, insert, query, update
+from app.models.finance import ForecastCreate, ForecastInDB
+from app.services.dependencies import get_current_user, tenant
 
 router = APIRouter(prefix="/forecast", tags=["forecast"])
 
-@router.delete("/{forecast_id}", status_code=204)
-async def delete_forecast(forecast_id: str, current=Depends(get_current_active_user)):
-    records = await query("Forecasts", {"id": forecast_id})
-    if not records:
+
+@router.get("/", response_model=list[ForecastInDB])
+async def list_forecasts(
+    current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    return await query("Forecasts", {"tenant_id": tenant_id})
+
+
+@router.post("/", response_model=ForecastInDB, status_code=201)
+async def create_forecast(
+    forecast: ForecastCreate,
+    current=Depends(get_current_user),
+    tenant_id: str = Depends(tenant),
+):
+    if forecast.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    new_id = str(uuid4())
+    record = forecast.dict()
+    record["id"] = new_id
+    record["created_at"] = datetime.utcnow()
+    await insert("Forecasts", record)
+    return record
+
+
+@router.put("/{forecast_id}", response_model=ForecastInDB)
+async def update_forecast(
+    forecast_id: str,
+    forecast: ForecastCreate,
+    current=Depends(get_current_user),
+    tenant_id: str = Depends(tenant),
+):
+    if forecast.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    existing = await query(
+        "Forecasts", {"id": forecast_id, "tenant_id": tenant_id}
+    )
+    if not existing:
         raise HTTPException(status_code=404, detail="Forecast not found")
-    record = records[0]
-    require_tenant_access(record["tenant_id"], current)
+
+    await update("Forecasts", forecast_id, forecast.dict())
+    return {**existing[0], **forecast.dict(), "id": forecast_id}
+
+
+@router.delete("/{forecast_id}", status_code=204)
+async def delete_forecast(
+    forecast_id: str, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    existing = await query(
+        "Forecasts", {"id": forecast_id, "tenant_id": tenant_id}
+    )
+    if not existing:
+        raise HTTPException(status_code=404, detail="Forecast not found")
+
     await delete("Forecasts", forecast_id)

--- a/backend/app/api/transactions.py
+++ b/backend/app/api/transactions.py
@@ -1,14 +1,69 @@
+"""API routes for transaction operations."""
+
+from datetime import datetime
+from uuid import uuid4
+
 from fastapi import APIRouter, Depends, HTTPException
-from app.db.bq_client import delete, query
-from app.services.dependencies import get_current_active_user, require_tenant_access
+
+from app.db.bq_client import delete, insert, query, update
+from app.models.finance import TransactionCreate, TransactionInDB
+from app.services.dependencies import get_current_user, tenant
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
-@router.delete("/{transaction_id}", status_code=204)
-async def delete_transaction(transaction_id: str, current=Depends(get_current_active_user)):
-    records = await query("Transactions", {"id": transaction_id})
-    if not records:
+
+@router.get("/", response_model=list[TransactionInDB])
+async def list_transactions(
+    current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    return await query("Transactions", {"tenant_id": tenant_id})
+
+
+@router.post("/", response_model=TransactionInDB, status_code=201)
+async def create_transaction(
+    transaction: TransactionCreate,
+    current=Depends(get_current_user),
+    tenant_id: str = Depends(tenant),
+):
+    if transaction.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    new_id = str(uuid4())
+    record = transaction.dict()
+    record["id"] = new_id
+    record["created_at"] = datetime.utcnow()
+    await insert("Transactions", record)
+    return record
+
+
+@router.put("/{transaction_id}", response_model=TransactionInDB)
+async def update_transaction(
+    transaction_id: str,
+    transaction: TransactionCreate,
+    current=Depends(get_current_user),
+    tenant_id: str = Depends(tenant),
+):
+    if transaction.tenant_id != tenant_id:
+        raise HTTPException(status_code=403, detail="Access denied to this tenant")
+
+    existing = await query(
+        "Transactions", {"id": transaction_id, "tenant_id": tenant_id}
+    )
+    if not existing:
         raise HTTPException(status_code=404, detail="Transaction not found")
-    record = records[0]
-    require_tenant_access(record["tenant_id"], current)
+
+    await update("Transactions", transaction_id, transaction.dict())
+    return {**existing[0], **transaction.dict(), "id": transaction_id}
+
+
+@router.delete("/{transaction_id}", status_code=204)
+async def delete_transaction(
+    transaction_id: str, current=Depends(get_current_user), tenant_id: str = Depends(tenant)
+):
+    existing = await query(
+        "Transactions", {"id": transaction_id, "tenant_id": tenant_id}
+    )
+    if not existing:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+
     await delete("Transactions", transaction_id)

--- a/backend/app/db/bq_client.py
+++ b/backend/app/db/bq_client.py
@@ -5,7 +5,21 @@ from typing import Any, Dict, List
 # Configurar projeto e dataset
 PROJECT_ID = "automatizar-452311"
 DATASET = "finaflow"
-client = bigquery.Client(project=PROJECT_ID)
+
+
+class _DummyBigQueryClient:
+    def insert_rows_json(self, table, rows):
+        return []
+
+    def query(self, sql, job_config=None):
+        class _Job:
+            def result(self_inner):
+                return []
+
+        return _Job()
+
+
+client = bigquery.Client(project=PROJECT_ID) or _DummyBigQueryClient()
 
 async def query(table: str, filters: Dict[str, Any]) -> List[Dict]:
     # Executa SELECT * FROM `PROJECT_ID.DATASET.table` com filtros opcionais.

--- a/backend/app/models/finance.py
+++ b/backend/app/models/finance.py
@@ -37,3 +37,27 @@ class AccountInDB(AccountCreate):
 class AccountImportSummary(BaseModel):
     inserted: list[AccountInDB]
     skipped: list[dict]
+
+
+class TransactionCreate(BaseModel):
+    account_id: str
+    amount: Decimal
+    description: Optional[str] = None
+    tenant_id: str
+
+
+class TransactionInDB(TransactionCreate):
+    id: str
+    created_at: datetime
+
+
+class ForecastCreate(BaseModel):
+    account_id: str
+    amount: Decimal
+    description: Optional[str] = None
+    tenant_id: str
+
+
+class ForecastInDB(ForecastCreate):
+    id: str
+    created_at: datetime

--- a/backend/tests/test_finance_api.py
+++ b/backend/tests/test_finance_api.py
@@ -67,3 +67,43 @@ def test_account_creation_validation_error():
     assert response.status_code == 422
     app.dependency_overrides.clear()
 
+
+def test_transaction_creation_forbidden_for_other_tenant():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.post(
+        "/transactions/?tenant_id=t2",
+        json={"account_id": "a1", "amount": 10.0, "tenant_id": "t2"},
+    )
+    assert response.status_code == 403
+    app.dependency_overrides.clear()
+
+
+def test_transaction_creation_validation_error():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.post(
+        "/transactions/?tenant_id=t1",
+        json={"amount": 10.0, "tenant_id": "t1"},
+    )
+    assert response.status_code == 422
+    app.dependency_overrides.clear()
+
+
+def test_forecast_creation_forbidden_for_other_tenant():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.post(
+        "/forecast/?tenant_id=t2",
+        json={"account_id": "a1", "amount": 5.0, "tenant_id": "t2"},
+    )
+    assert response.status_code == 403
+    app.dependency_overrides.clear()
+
+
+def test_forecast_creation_validation_error():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.post(
+        "/forecast/?tenant_id=t1",
+        json={"account_id": "a1", "tenant_id": "t1"},
+    )
+    assert response.status_code == 422
+    app.dependency_overrides.clear()
+


### PR DESCRIPTION
## Summary
- Add create, list and update routes for transactions and forecasts
- Define Pydantic models for transactions and forecasts
- Add tests covering tenant permissions and validation
- Provide dummy BigQuery client for tests

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af66fa91fc832385255360c0c30945