### PR TITLE
Respect initial account balance on account creation

### DIFF
--- a/backend/app/api/accounts.py
+++ b/backend/app/api/accounts.py
@@ -33,7 +33,7 @@ async def create_account(
     new_id = str(uuid4())
     record = account.dict()
     record["id"] = new_id
-    record["balance"] = Decimal("0")
+    record["created_at"] = datetime.utcnow()
     await insert("Accounts", record)
     return record
 

--- a/backend/tests/test_finance_api.py
+++ b/backend/tests/test_finance_api.py
@@ -68,6 +68,18 @@ def test_account_creation_validation_error():
     app.dependency_overrides.clear()
 
 
+def test_account_creation_respects_balance():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+    response = client.post(
+        "/accounts/?tenant_id=t1",
+        json={"subgroup_id": "s1", "name": "acc1", "balance": 123.45, "tenant_id": "t1"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert float(data["balance"]) == 123.45
+    app.dependency_overrides.clear()
+
+
 def test_transaction_creation_forbidden_for_other_tenant():
     app.dependency_overrides[get_current_user] = override_tenant_user
     response = client.post(


### PR DESCRIPTION
## Summary
- stop overriding provided balance when creating an account
- ensure account creation returns `created_at`
- cover account balance preservation in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6893f5288323adbc1f95cb69e7a1