### PR TITLE
Run BigQuery calls in worker threads

### DIFF
--- a/backend/app/api/groups.py
+++ b/backend/app/api/groups.py
@@ -1,7 +1,14 @@
 from fastapi import APIRouter, Depends, HTTPException
 from uuid import uuid4
+
+import asyncio
+
 from app.models.finance import GroupCreate, GroupInDB
-from app.services.dependencies import get_current_active_user, require_super_admin, require_tenant_access
+from app.services.dependencies import (
+    get_current_active_user,
+    require_super_admin,
+    require_tenant_access,
+)
 from app.db.bq_client import insert, query
 
 router = APIRouter(prefix="/groups", tags=["groups"])
@@ -9,13 +16,13 @@ router = APIRouter(prefix="/groups", tags=["groups"])
 @router.get("/", response_model=list[GroupInDB])
 async def list_groups(current=Depends(get_current_active_user)):
     if current.role.value == "tenant_user":
-        return await query("Groups", {"tenant_id": current.tenant_id})
-    return await query("Groups", {})
+        return await asyncio.to_thread(query, "Groups", {"tenant_id": current.tenant_id})
+    return await asyncio.to_thread(query, "Groups", {})
 
 @router.post("/", response_model=GroupInDB, status_code=201)
 async def create_group(group: GroupCreate, current=Depends(require_super_admin)):
     gid = str(uuid4())
     rec = group.dict()
     rec["id"] = gid
-    await insert("Groups", rec)
+    await asyncio.to_thread(insert, "Groups", rec)
     return rec

--- a/backend/app/api/tenants.py
+++ b/backend/app/api/tenants.py
@@ -1,23 +1,26 @@
 from fastapi import APIRouter, Depends, HTTPException
 from uuid import uuid4
+
+import asyncio
+
 from app.models.tenant import TenantCreate, TenantInDB
 from app.services.dependencies import require_super_admin, get_current_active_user
-from app.db.bq_client import insert, query
+from app.db.bq_client import delete, insert, query
 
 router = APIRouter(prefix="/tenants", tags=["tenants"])
 
 @router.get("/", response_model=list[TenantInDB])
 async def list_tenants(current=Depends(get_current_active_user)):
-    return await query("Tenants", {})
+    return await asyncio.to_thread(query, "Tenants", {})
 
 @router.post("/", response_model=TenantInDB, status_code=201)
 async def create_tenant(tenant: TenantCreate, current=Depends(require_super_admin)):
     new_id = str(uuid4())
     record = tenant.dict()
     record["id"] = new_id
-    await insert("Tenants", record)
+    await asyncio.to_thread(insert, "Tenants", record)
     return record
 
 @router.delete("/{tenant_id}", status_code=204)
 async def delete_tenant(tenant_id: str, current=Depends(require_super_admin)):
-    await delete("Tenants", tenant_id)
+    await asyncio.to_thread(delete, "Tenants", tenant_id)

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,16 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException
 from uuid import uuid4
+
+import asyncio
+
 from app.models.user import UserCreate, UserInDB
 from app.services.security import hash_password
 from app.services.dependencies import require_super_admin, get_current_active_user
-from app.db.bq_client import insert
+from app.db.bq_client import delete, insert, query
 
 router = APIRouter(prefix="/users", tags=["users"])
 
 @router.get("/", response_model=list[UserInDB])
 async def list_users(current=Depends(get_current_active_user)):
     # exemplo: super_admin vê todos; tenant_user pode filtrar
-    return await query("Users", {})
+    return await asyncio.to_thread(query, "Users", {})
 
 @router.post("/", response_model=UserInDB, status_code=201)
 async def create_user(user: UserCreate, current=Depends(require_super_admin)):
@@ -24,9 +27,9 @@ async def create_user(user: UserCreate, current=Depends(require_super_admin)):
         "role": user.role.value,
         "tenant_id": user.tenant_id,
     }
-    await insert("Users", record)
+    await asyncio.to_thread(insert, "Users", record)
     return record
 
 @router.delete("/{user_id}", status_code=204)
 async def delete_user(user_id: str, current=Depends(require_super_admin)):
-    await delete("Users", user_id)
+    await asyncio.to_thread(delete, "Users", user_id)

--- a/backend/app/db/bq_client.py
+++ b/backend/app/db/bq_client.py
@@ -21,8 +21,9 @@ class _DummyBigQueryClient:
 
 client = bigquery.Client(project=PROJECT_ID) or _DummyBigQueryClient()
 
-async def query(table: str, filters: Dict[str, Any]) -> List[Dict]:
-    # Executa SELECT * FROM `PROJECT_ID.DATASET.table` com filtros opcionais.
+
+def query(table: str, filters: Dict[str, Any]) -> List[Dict]:
+    """Executa ``SELECT *`` com filtros opcionais."""
     table_ref = f"`{PROJECT_ID}.{DATASET}.{table}`"
     sql = f"SELECT * FROM {table_ref}"
     params = []
@@ -37,14 +38,16 @@ async def query(table: str, filters: Dict[str, Any]) -> List[Dict]:
     rows = job.result()
     return [dict(row) for row in rows]
 
-async def insert(table: str, row: Dict[str, Any]):
-    # Insere uma linha JSON na tabela especificada.
+
+def insert(table: str, row: Dict[str, Any]):
+    """Insere uma linha JSON na tabela especificada."""
     table_ref = f"{PROJECT_ID}.{DATASET}.{table}"
     errors = client.insert_rows_json(table_ref, [row])
     if errors:
         raise RuntimeError(f"Error inserting into {table}: {errors}")
 
-async def insert_many(table: str, rows: List[Dict[str, Any]]):
+
+def insert_many(table: str, rows: List[Dict[str, Any]]):
     """Insert multiple JSON rows into the specified table.
 
     Raises:
@@ -55,11 +58,12 @@ async def insert_many(table: str, rows: List[Dict[str, Any]]):
     if errors:
         raise RuntimeError(f"Error inserting into {table}: {errors}")
 
-async def update(table: str, id: str, data: Dict[str, Any]):
-    # Atualiza uma linha por id na tabela especificada.
+
+def update(table: str, id: str, data: Dict[str, Any]):
+    """Atualiza uma linha por ``id`` na tabela especificada."""
     set_clause = ", ".join([f"{k}=@{k}" for k in data.keys()])
     table_ref = f"`{PROJECT_ID}.{DATASET}.{table}`"
-    sql = f""" 
+    sql = f"""
 UPDATE {table_ref}
 SET {set_clause}
 WHERE id=@id
@@ -69,13 +73,17 @@ WHERE id=@id
         params.append(bigquery.ScalarQueryParameter(k, "STRING", v))
     client.query(sql, job_config=QueryJobConfig(query_parameters=params)).result()
 
-async def delete(table: str, id: str):
-    # Deleta uma linha por id na tabela especificada.
+
+def delete(table: str, id: str):
+    """Deleta uma linha por ``id`` na tabela especificada."""
     table_ref = f"`{PROJECT_ID}.{DATASET}.{table}`"
     sql = f"DELETE FROM {table_ref} WHERE id=@id"
-    job_config = QueryJobConfig(query_parameters=[bigquery.ScalarQueryParameter("id", "STRING", id)])
+    job_config = QueryJobConfig(
+        query_parameters=[bigquery.ScalarQueryParameter("id", "STRING", id)]
+    )
     client.query(sql, job_config=job_config).result()
 
-async def query_user(username: str):
-    # Busca usuário por username na tabela Users.
-    return await query("Users", {"username": username})
+
+def query_user(username: str):
+    """Busca usuário por ``username`` na tabela ``Users``."""
+    return query("Users", {"username": username})

--- a/backend/app/services/reporting.py
+++ b/backend/app/services/reporting.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Any, Dict, List
 
+import asyncio
 from app.db.bq_client import query
 
 CASH_FLOW_TABLE = "CashFlow"
@@ -25,7 +26,7 @@ async def cash_flow_summary(group_by: str, tenant_id: str) -> Any:
         totals ordered by the period.
     """
 
-    rows = await query(CASH_FLOW_TABLE, {"tenant_id": tenant_id})
+    rows = await asyncio.to_thread(query, CASH_FLOW_TABLE, {"tenant_id": tenant_id})
 
     totals: Dict[str, Dict[str, float]] = defaultdict(lambda: {"predicted": 0.0, "realized": 0.0})
 

--- a/backend/tests/test_reporting.py
+++ b/backend/tests/test_reporting.py
@@ -12,7 +12,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 def _load_service_with_query(sample):
     recorded = {}
 
-    async def fake_query(table, filters):
+    def fake_query(table, filters):
         recorded["filters"] = filters
         tenant_id = filters.get("tenant_id")
         return [row for row in sample if row.get("tenant_id") == tenant_id]


### PR DESCRIPTION
## Summary
- Convert BigQuery helper functions to synchronous implementations
- Call BigQuery operations from API handlers via `asyncio.to_thread` to avoid blocking
- Adjust tests to use the new synchronous BigQuery interface

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af69dddde083238cb5c59438d39fd7