### PR TITLE
Fallback to dummy BigQuery client on init failure

### DIFF
--- a/backend/app/db/bq_client.py
+++ b/backend/app/db/bq_client.py
@@ -19,7 +19,12 @@ class _DummyBigQueryClient:
         return _Job()
 
 
-client = bigquery.Client(project=PROJECT_ID) or _DummyBigQueryClient()
+try:
+    client = bigquery.Client(project=PROJECT_ID)
+    if client is None:
+        client = _DummyBigQueryClient()
+except Exception:
+    client = _DummyBigQueryClient()
 
 
 def query(table: str, filters: Dict[str, Any]) -> List[Dict]:


### PR DESCRIPTION
## Summary
- wrap BigQuery client creation in try/except and use _DummyBigQueryClient when initialization fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6f7480a48323a2b1d871f60e1aa9