### PR TITLE
Add quiet flag to Cloud Run deploy

### DIFF
--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -74,6 +74,7 @@ steps:
       - '1'
       - '--max-instances'
       - '10'
+      - '--quiet'
 
 images:
   - 'gcr.io/$PROJECT_ID/finaflow-backend:$SHORT_SHA'


### PR DESCRIPTION
## Summary
- add `--quiet` flag to Cloud Run deployment in Cloud Build config to avoid interactive prompts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af6f910ca0832396dfa7379b507aca