### PR TITLE
chore: add email validator dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ python-jose
 pydantic
 pytest
 google-cloud-bigquery
+email-validator


### PR DESCRIPTION
## Summary
- ensure backend installs email-validator for EmailStr support

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests -q`
- `docker build -t backend-image backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af74b624388323969e598e2753ea51