### PR TITLE
feat: configure JWT secret for Cloud Run deployment

### DIFF
--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -74,6 +74,11 @@ steps:
       - '1'
       - '--max-instances'
       - '10'
+      - '--set-env-vars'
+      - 'JWT_SECRET=$_JWT_SECRET'
+      # Alternativamente, use Secrets do GCP:
+      # - '--update-secrets'
+      # - 'JWT_SECRET=projects/$PROJECT_ID/secrets/JWT_SECRET:latest'
       - '--quiet'
 
 images:


### PR DESCRIPTION
## Summary
- set `JWT_SECRET` env var during Cloud Run deployment
- document alternative use of GCP Secrets Manager

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af8902c1388323a37a47fe4f1796d0