### PR TITLE
chore: run tests in single cloud build step

### DIFF
--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -2,35 +2,18 @@ options:
   logging: CLOUD_LOGGING_ONLY
 
 steps:
-  - id: 'Upgrade pip'
-    name: 'python:3.11'
-    dir: 'backend'
-    entrypoint: 'python3'
-    args:
-      - '-m'
-      - 'pip'
-      - 'install'
-      - '--upgrade'
-      - 'pip'
-
-  - id: 'Instalar requirements'
-    name: 'python:3.11'
-    dir: 'backend'
-    entrypoint: 'python3'
-    args:
-      - '-m'
-      - 'pip'
-      - 'install'
-      - '-r'
-      - 'requirements.txt'
-
-  - id: 'Rodar testes (não-fatal)'
+  - id: 'Instalar requirements e rodar testes (não-fatal)'
     name: 'python:3.11'
     dir: 'backend'
     entrypoint: 'bash'
+    volumes:
+      - name: pip-cache
+        path: /root/.cache/pip
     args:
       - '-c'
       - |
+        pip install --upgrade pip
+        pip install -r requirements.txt
         pytest --maxfail=1 --disable-warnings || true
 
   - id: 'Build Docker'


### PR DESCRIPTION
## Summary
- run dependency install and tests in one Cloud Build step
- cache pip installs to speed up builds

## Testing
- `pip install -r backend/requirements.txt`
- `pytest` *(fails: `PydanticImportError: BaseSettings has been moved to the pydantic-settings package`)*

------
https://chatgpt.com/codex/tasks/task_e_68af8a4742a883238c839ea9900cdead