### PR TITLE
share pip cache volume across build steps

### DIFF
--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -18,6 +18,9 @@ steps:
 
   - id: 'Build Docker'
     name: 'gcr.io/cloud-builders/docker'
+    volumes:
+      - name: pip-cache
+        path: /root/.cache/pip
     args:
       - 'build'
       - '-t'


### PR DESCRIPTION
## Summary
- mount pip cache volume in the Build Docker step so the volume is used by multiple steps

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af8e44e8f4832399d886f3e64ccf60