### PR TITLE
refactor: move BigQuery configuration to settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     JWT_SECRET: str
     JWT_ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    PROJECT_ID: str
+    DATASET: str
 
     class Config:
         env_file = ".env"

--- a/backend/app/db/bq_client.py
+++ b/backend/app/db/bq_client.py
@@ -2,9 +2,9 @@ from google.cloud import bigquery
 from google.cloud.bigquery import QueryJobConfig
 from typing import Any, Dict, List
 
-# Configurar projeto e dataset
-PROJECT_ID = "automatizar-452311"
-DATASET = "finaflow"
+from app.config import Settings
+
+settings = Settings()
 
 
 class _DummyBigQueryClient:
@@ -20,7 +20,7 @@ class _DummyBigQueryClient:
 
 
 try:
-    client = bigquery.Client(project=PROJECT_ID)
+    client = bigquery.Client(project=settings.PROJECT_ID)
     if client is None:
         client = _DummyBigQueryClient()
 except Exception:
@@ -29,7 +29,7 @@ except Exception:
 
 def query(table: str, filters: Dict[str, Any]) -> List[Dict]:
     """Executa ``SELECT *`` com filtros opcionais."""
-    table_ref = f"`{PROJECT_ID}.{DATASET}.{table}`"
+    table_ref = f"`{settings.PROJECT_ID}.{settings.DATASET}.{table}`"
     sql = f"SELECT * FROM {table_ref}"
     params = []
     if filters:
@@ -46,7 +46,7 @@ def query(table: str, filters: Dict[str, Any]) -> List[Dict]:
 
 def insert(table: str, row: Dict[str, Any]):
     """Insere uma linha JSON na tabela especificada."""
-    table_ref = f"{PROJECT_ID}.{DATASET}.{table}"
+    table_ref = f"{settings.PROJECT_ID}.{settings.DATASET}.{table}"
     errors = client.insert_rows_json(table_ref, [row])
     if errors:
         raise RuntimeError(f"Error inserting into {table}: {errors}")
@@ -58,7 +58,7 @@ def insert_many(table: str, rows: List[Dict[str, Any]]):
     Raises:
         RuntimeError: If BigQuery reports any insertion errors.
     """
-    table_ref = f"{PROJECT_ID}.{DATASET}.{table}"
+    table_ref = f"{settings.PROJECT_ID}.{settings.DATASET}.{table}"
     errors = client.insert_rows_json(table_ref, rows)
     if errors:
         raise RuntimeError(f"Error inserting into {table}: {errors}")
@@ -67,7 +67,7 @@ def insert_many(table: str, rows: List[Dict[str, Any]]):
 def update(table: str, id: str, data: Dict[str, Any]):
     """Atualiza uma linha por ``id`` na tabela especificada."""
     set_clause = ", ".join([f"{k}=@{k}" for k in data.keys()])
-    table_ref = f"`{PROJECT_ID}.{DATASET}.{table}`"
+    table_ref = f"`{settings.PROJECT_ID}.{settings.DATASET}.{table}`"
     sql = f"""
 UPDATE {table_ref}
 SET {set_clause}
@@ -81,7 +81,7 @@ WHERE id=@id
 
 def delete(table: str, id: str):
     """Deleta uma linha por ``id`` na tabela especificada."""
-    table_ref = f"`{PROJECT_ID}.{DATASET}.{table}`"
+    table_ref = f"`{settings.PROJECT_ID}.{settings.DATASET}.{table}`"
     sql = f"DELETE FROM {table_ref} WHERE id=@id"
     job_config = QueryJobConfig(
         query_parameters=[bigquery.ScalarQueryParameter("id", "STRING", id)]

--- a/backend/tests/test_account_import.py
+++ b/backend/tests/test_account_import.py
@@ -16,6 +16,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 # Provide required configuration variables for Settings
 os.environ.setdefault("JWT_SECRET", "testing-secret")
+os.environ.setdefault("PROJECT_ID", "test-project")
+os.environ.setdefault("DATASET", "test-dataset")
 
 from app.models.user import Role, UserInDB  # noqa: E402
 from app.services.dependencies import get_current_user  # noqa: E402

--- a/backend/tests/test_finance_api.py
+++ b/backend/tests/test_finance_api.py
@@ -22,6 +22,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 # Provide required configuration variables for Settings
 os.environ.setdefault("JWT_SECRET", "testing-secret")
+os.environ.setdefault("PROJECT_ID", "test-project")
+os.environ.setdefault("DATASET", "test-dataset")
 
 from app.main import app  # noqa: E402
 from app.models.user import Role, UserInDB  # noqa: E402


### PR DESCRIPTION
## Summary
- load BigQuery project and dataset from Settings
- expose project and dataset as configurable options
- update tests for new configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0504307108323ac1df8c054fbbefd