### PR TITLE
feat: allow signup without token

### DIFF
--- a/frontend/__tests__/AuthContext.test.tsx
+++ b/frontend/__tests__/AuthContext.test.tsx
@@ -11,11 +11,13 @@ jest.mock('jwt-decode', () => jest.fn());
 
 const api = require('../services/api');
 const mockedLogin = api.login as jest.Mock;
+const mockedSignup = api.signup as jest.Mock;
 const mockedJwtDecode = require('jwt-decode') as jest.Mock;
 
 describe('AuthContext', () => {
   beforeEach(() => {
     localStorage.clear();
+    jest.clearAllMocks();
   });
 
   test('login stores token and user info', async () => {
@@ -65,5 +67,59 @@ describe('AuthContext', () => {
     expect(ctx.token).toBeNull();
     expect(ctx.role).toBeNull();
     expect(ctx.tenantId).toBeNull();
+  });
+
+  test('signup works without token', async () => {
+    mockedSignup.mockResolvedValue({});
+
+    let ctx: any;
+    const Consumer = () => {
+      ctx = useContext(AuthContext);
+      return null;
+    };
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    );
+
+    await act(async () => {
+      await ctx.signup({ username: 'new', password: 'pass' });
+    });
+
+    expect(mockedSignup).toHaveBeenCalledWith(
+      { username: 'new', password: 'pass' },
+      undefined
+    );
+  });
+
+  test('signup uses token when available', async () => {
+    mockedLogin.mockResolvedValue({ access_token: 'token123' });
+    mockedJwtDecode.mockReturnValue({ role: 'user', tenant_id: null });
+    mockedSignup.mockResolvedValue({});
+
+    let ctx: any;
+    const Consumer = () => {
+      ctx = useContext(AuthContext);
+      return null;
+    };
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>
+    );
+
+    await act(async () => {
+      await ctx.login('user', 'pass');
+    });
+
+    await act(async () => {
+      await ctx.signup({ username: 'new', password: 'pass' });
+    });
+
+    expect(mockedSignup).toHaveBeenCalledWith(
+      { username: 'new', password: 'pass' },
+      'token123'
+    );
   });
 });

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -38,7 +38,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const signup = async (data: any) => {
-    const response = await apiSignup(data, token!);
+    const response = await apiSignup(data, token ?? undefined);
     return response;
   };
 


### PR DESCRIPTION
## Summary
- allow AuthContext signup to work without a token
- test signup behavior with and without token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b061e104508323ba401a8408d2caa0