### PR TITLE
Restrict cash flow grouping to month/day

### DIFF
--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -1,4 +1,7 @@
+from typing import Literal
+
 from fastapi import APIRouter, Depends
+
 from app.services.reporting import cash_flow_summary
 from app.services.dependencies import get_current_active_user, tenant
 
@@ -6,7 +9,7 @@ router = APIRouter(prefix="/reports", tags=["reports"])
 
 @router.get("/cash-flow")
 async def cash_flow(
-    group_by: str = "month",
+    group_by: Literal["month", "day"] = "month",
     tenant_id: str = Depends(tenant),
     current=Depends(get_current_active_user),
 ):

--- a/backend/tests/test_finance_api.py
+++ b/backend/tests/test_finance_api.py
@@ -147,6 +147,15 @@ def test_cash_flow_endpoint_isolates_tenant(monkeypatch):
     app.dependency_overrides.clear()
 
 
+def test_cash_flow_endpoint_rejects_invalid_group_by():
+    app.dependency_overrides[get_current_user] = override_tenant_user
+
+    response = client.get("/reports/cash-flow?group_by=year")
+    assert response.status_code == 422
+
+    app.dependency_overrides.clear()
+
+
 def test_transactions_list_isolates_tenant(monkeypatch):
     app.dependency_overrides[get_current_user] = override_tenant_user
     sample = [


### PR DESCRIPTION
## Summary
- Limit `/reports/cash-flow` grouping options to "month" or "day"
- Add tests for invalid `group_by` values returning 422

## Testing
- `cd backend && pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b06438f48c8323be96d3062ffd6d0c