### PR TITLE
feat: add groups and related pages

### DIFF
--- a/frontend/components/layout/Layout.tsx
+++ b/frontend/components/layout/Layout.tsx
@@ -5,6 +5,10 @@ import {
   Users,
   CreditCard,
   BarChart3,
+  Layers,
+  Layers3,
+  Wallet,
+  TrendingUp,
   Settings,
   LogOut,
   Menu,
@@ -34,6 +38,10 @@ const Layout: React.FC<LayoutProps> = ({ children, title }) => {
     { icon: <Users className="w-5 h-5" />, label: 'Usuários', href: '/users', active: title === 'Usuários' },
     { icon: <CreditCard className="w-5 h-5" />, label: 'Transações', href: '/transactions', active: title === 'Transações' },
     { icon: <BarChart3 className="w-5 h-5" />, label: 'Relatórios', href: '/reports', active: title === 'Relatórios' },
+    { icon: <Layers className="w-5 h-5" />, label: 'Groups', href: '/groups', active: title === 'Groups' },
+    { icon: <Layers3 className="w-5 h-5" />, label: 'Subgroups', href: '/subgroups', active: title === 'Subgroups' },
+    { icon: <Wallet className="w-5 h-5" />, label: 'Accounts', href: '/accounts', active: title === 'Accounts' },
+    { icon: <TrendingUp className="w-5 h-5" />, label: 'Forecasts', href: '/forecasts', active: title === 'Forecasts' },
     { icon: <Settings className="w-5 h-5" />, label: 'Configurações', href: '/settings', active: title === 'Configurações' },
   ];
 

--- a/frontend/pages/accounts.tsx
+++ b/frontend/pages/accounts.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Layout from '../components/layout/Layout';
+import Card from '../components/ui/Card';
+
+export default function Accounts() {
+  return (
+    <Layout title="Accounts">
+      <div className="space-y-6">
+        <Card>
+          <Card.Header>
+            <h2 className="text-xl font-semibold">Accounts</h2>
+          </Card.Header>
+          <Card.Body>
+            <p className="text-gray-600">Accounts management coming soon.</p>
+          </Card.Body>
+        </Card>
+      </div>
+    </Layout>
+  );
+}
+

--- a/frontend/pages/forecasts.tsx
+++ b/frontend/pages/forecasts.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Layout from '../components/layout/Layout';
+import Card from '../components/ui/Card';
+
+export default function Forecasts() {
+  return (
+    <Layout title="Forecasts">
+      <div className="space-y-6">
+        <Card>
+          <Card.Header>
+            <h2 className="text-xl font-semibold">Forecasts</h2>
+          </Card.Header>
+          <Card.Body>
+            <p className="text-gray-600">Forecast analytics will appear here.</p>
+          </Card.Body>
+        </Card>
+      </div>
+    </Layout>
+  );
+}
+

--- a/frontend/pages/groups.tsx
+++ b/frontend/pages/groups.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Layout from '../components/layout/Layout';
+import Card from '../components/ui/Card';
+
+export default function Groups() {
+  return (
+    <Layout title="Groups">
+      <div className="space-y-6">
+        <Card>
+          <Card.Header>
+            <h2 className="text-xl font-semibold">Groups</h2>
+          </Card.Header>
+          <Card.Body>
+            <p className="text-gray-600">Manage your groups here.</p>
+          </Card.Body>
+        </Card>
+      </div>
+    </Layout>
+  );
+}
+

--- a/frontend/pages/subgroups.tsx
+++ b/frontend/pages/subgroups.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Layout from '../components/layout/Layout';
+import Card from '../components/ui/Card';
+
+export default function Subgroups() {
+  return (
+    <Layout title="Subgroups">
+      <div className="space-y-6">
+        <Card>
+          <Card.Header>
+            <h2 className="text-xl font-semibold">Subgroups</h2>
+          </Card.Header>
+          <Card.Body>
+            <p className="text-gray-600">Organize subgroups here.</p>
+          </Card.Body>
+        </Card>
+      </div>
+    </Layout>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add navigation links for groups, subgroups, accounts and forecasts
- add placeholder pages for the new sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06be4d0888323843f4bffd127f108