### PR TITLE
Add API service helpers for users, accounts, transactions, and forecasts

### DIFF
--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -24,4 +24,112 @@ export const getCashFlowReport = async (groupBy: string = 'month', token?: strin
   return response.data;
 };
 
+// User endpoints
+export const getUsers = async (token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.get('/users', { headers });
+  return response.data;
+};
+
+export const createUser = async (data: any, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.post('/users', data, { headers });
+  return response.data;
+};
+
+export const updateUser = async (userId: string, data: any, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.put(`/users/${userId}`, data, { headers });
+  return response.data;
+};
+
+export const deleteUser = async (userId: string, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.delete(`/users/${userId}`, { headers });
+  return response.data;
+};
+
+// Account endpoints
+export const getAccounts = async (token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.get('/accounts', { headers });
+  return response.data;
+};
+
+export const createAccount = async (data: any, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.post('/accounts', data, { headers });
+  return response.data;
+};
+
+export const updateAccount = async (accountId: string, data: any, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.put(`/accounts/${accountId}`, data, { headers });
+  return response.data;
+};
+
+export const deleteAccount = async (accountId: string, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.delete(`/accounts/${accountId}`, { headers });
+  return response.data;
+};
+
+// Transaction endpoints
+export const getTransactions = async (token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.get('/transactions', { headers });
+  return response.data;
+};
+
+export const createTransaction = async (data: any, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.post('/transactions', data, { headers });
+  return response.data;
+};
+
+export const updateTransaction = async (
+  transactionId: string,
+  data: any,
+  token?: string,
+) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.put(`/transactions/${transactionId}`, data, { headers });
+  return response.data;
+};
+
+export const deleteTransaction = async (transactionId: string, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.delete(`/transactions/${transactionId}`, { headers });
+  return response.data;
+};
+
+// Forecast endpoints
+export const getForecasts = async (token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.get('/forecast', { headers });
+  return response.data;
+};
+
+export const createForecast = async (data: any, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.post('/forecast', data, { headers });
+  return response.data;
+};
+
+export const updateForecast = async (
+  forecastId: string,
+  data: any,
+  token?: string,
+) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.put(`/forecast/${forecastId}`, data, { headers });
+  return response.data;
+};
+
+export const deleteForecast = async (forecastId: string, token?: string) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.delete(`/forecast/${forecastId}`, { headers });
+  return response.data;
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- extend API service with user CRUD helpers
- add account, transaction, and forecast endpoints supporting optional auth token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06d10bd2883238d4825d850f335e6