### PR TITLE
Add CSV import utility and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
+### Importar dados CSV
+
+Para carregar dados a partir de arquivos CSV para tabelas do BigQuery utilize
+o script de importação:
+
+```bash
+cd backend
+python import_csv.py --table PlanOfAccounts csv/arquivo.csv
+```
+
+Pré-requisitos:
+
+* Variável de ambiente `GOOGLE_APPLICATION_CREDENTIALS` apontando para o
+  arquivo de credenciais do Google Cloud;
+* Variáveis `PROJECT_ID` e `DATASET` definindo o destino das tabelas.
+
 ### Frontend
 
 ```bash

--- a/backend/app/services/csv_importer.py
+++ b/backend/app/services/csv_importer.py
@@ -1,0 +1,31 @@
+"""Utilities for importing CSV files into BigQuery tables."""
+
+from __future__ import annotations
+
+from google.cloud import bigquery
+
+from app.db.bq_client import get_client, get_settings, _format_table
+
+
+def load_csv_to_table(csv_path: str, table: str, *, skip_leading_rows: int = 1) -> None:
+    """Load a CSV file into a BigQuery table truncating existing data.
+
+    Args:
+        csv_path: Path to the local CSV file.
+        table: Name of the destination table in BigQuery.
+        skip_leading_rows: Number of initial rows to skip (e.g. header row).
+    """
+
+    client = get_client()
+    settings = get_settings()
+    table_ref = _format_table(settings, table, quoted=False)
+
+    job_config = bigquery.LoadJobConfig(
+        source_format=bigquery.SourceFormat.CSV,
+        skip_leading_rows=skip_leading_rows,
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+    )
+
+    with open(csv_path, "rb") as csv_file:
+        job = client.load_table_from_file(csv_file, table_ref, job_config=job_config)
+        job.result()

--- a/backend/import_csv.py
+++ b/backend/import_csv.py
@@ -1,0 +1,35 @@
+"""CLI utility to import CSV files into BigQuery tables."""
+
+from __future__ import annotations
+
+import argparse
+
+from app.services.csv_importer import load_csv_to_table
+
+TABLE_CHOICES = ["PlanOfAccounts", "Transactions", "Forecasts"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Import CSV files into BigQuery tables"
+    )
+    parser.add_argument(
+        "csv_paths", nargs="+", help="Path(s) to CSV file(s) to import"
+    )
+    parser.add_argument(
+        "--table", "-t", required=True, choices=TABLE_CHOICES,
+        help="Destination table name"
+    )
+    parser.add_argument(
+        "--skip-leading-rows", type=int, default=1,
+        help="Number of initial rows to skip (default: 1)"
+    )
+
+    args = parser.parse_args()
+
+    for path in args.csv_paths:
+        load_csv_to_table(path, args.table, skip_leading_rows=args.skip_leading_rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_csv_importer.py
+++ b/backend/tests/test_csv_importer.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+from google.cloud import bigquery
+
+# Ensure the backend directory is on the Python path so ``app`` can be imported
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.services.csv_importer import load_csv_to_table  # noqa: E402
+
+
+def test_load_csv_to_table(monkeypatch, tmp_path):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("id\n1\n")
+
+    recorded: dict[str, object] = {}
+
+    class DummyClient:
+        def load_table_from_file(self, file_obj, table, job_config):  # pragma: no cover - call path
+            recorded["file_name"] = file_obj.name
+            recorded["table"] = table
+            recorded["job_config"] = job_config
+
+            class DummyJob:
+                def result(self_inner):
+                    return None
+
+            return DummyJob()
+
+    def fake_get_client():
+        return DummyClient()
+
+    def fake_get_settings():
+        return types.SimpleNamespace(PROJECT_ID="p", DATASET="d")
+
+    def fake_format_table(settings, table_name, quoted=False):
+        recorded["quoted"] = quoted
+        return f"{settings.PROJECT_ID}.{settings.DATASET}.{table_name}"
+
+    monkeypatch.setattr("app.services.csv_importer.get_client", fake_get_client)
+    monkeypatch.setattr("app.services.csv_importer.get_settings", fake_get_settings)
+    monkeypatch.setattr("app.services.csv_importer._format_table", fake_format_table)
+
+    load_csv_to_table(str(csv_file), "Transactions", skip_leading_rows=2)
+
+    assert recorded["file_name"] == str(csv_file)
+    assert recorded["table"] == "p.d.Transactions"
+    job_config = recorded["job_config"]
+    assert job_config.source_format == bigquery.SourceFormat.CSV
+    assert job_config.write_disposition == bigquery.WriteDisposition.WRITE_TRUNCATE
+    assert job_config.skip_leading_rows == 2
+    assert recorded["quoted"] is False


### PR DESCRIPTION
## Summary
- add service to load CSV files into BigQuery tables
- expose a CLI to import CSV files
- document CSV import usage in README

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b08fba23f08323bfad04a3766a14ec