### PR TITLE
feat: add CSV import endpoint and frontend page

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -7,6 +7,7 @@ from app.api.users import router as users_router
 from app.api.reports import router as reports_router
 from app.api.transactions import router as transactions_router
 from app.api.forecast import router as forecast_router
+from app.api.csv_import import router as csv_import_router
 
 
 def include_routers(app):
@@ -19,3 +20,4 @@ def include_routers(app):
     app.include_router(reports_router)
     app.include_router(transactions_router)
     app.include_router(forecast_router)
+    app.include_router(csv_import_router)

--- a/backend/app/api/csv_import.py
+++ b/backend/app/api/csv_import.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+import asyncio
+import tempfile
+import shutil
+import os
+
+from app.services.csv_importer import load_csv_to_table
+
+router = APIRouter(prefix="/import-csv", tags=["csv"])
+
+
+@router.post("/", status_code=201)
+async def import_csv(file: UploadFile = File(...), table: str = Form(...)):
+    """Import a CSV file into a BigQuery table."""
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            shutil.copyfileobj(file.file, tmp)
+            tmp_path = tmp.name
+        await asyncio.to_thread(load_csv_to_table, tmp_path, table)
+        return {"status": "success"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        file.file.close()
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)

--- a/frontend/pages/import-csv.tsx
+++ b/frontend/pages/import-csv.tsx
@@ -1,0 +1,73 @@
+'use client';
+import React, { useState, useContext } from 'react';
+import Layout from '../components/layout/Layout';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import { importCsv } from '../services/api';
+import { AuthContext } from '../context/AuthContext';
+
+export default function ImportCsvPage() {
+  const { token } = useContext(AuthContext);
+  const [file, setFile] = useState<File | null>(null);
+  const [table, setTable] = useState('PlanOfAccounts');
+  const [success, setSuccess] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    setLoading(true);
+    setSuccess('');
+    setError('');
+    try {
+      await importCsv(file, table, token ?? undefined);
+      setSuccess('Importação realizada com sucesso.');
+    } catch (err) {
+      setError('Erro ao importar CSV.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Layout title="Importar CSV">
+      <Card>
+        <Card.Body>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Arquivo CSV
+              </label>
+              <input
+                type="file"
+                accept=".csv"
+                onChange={(e) => setFile(e.target.files?.[0] || null)}
+                className="block w-full text-sm text-gray-700 border border-gray-300 rounded-lg cursor-pointer focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Tabela
+              </label>
+              <select
+                value={table}
+                onChange={(e) => setTable(e.target.value)}
+                className="input"
+              >
+                <option value="PlanOfAccounts">PlanOfAccounts</option>
+                <option value="Transactions">Transactions</option>
+                <option value="Forecasts">Forecasts</option>
+              </select>
+            </div>
+            <Button type="submit" variant="primary" loading={loading} disabled={!file}>
+              Importar
+            </Button>
+          </form>
+          {success && <p className="text-green-600 mt-4">{success}</p>}
+          {error && <p className="text-red-600 mt-4">{error}</p>}
+        </Card.Body>
+      </Card>
+    </Layout>
+  );
+}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -186,6 +186,16 @@ export const deleteForecast = async (forecastId: string, token?: string) => {
   return response.data;
 };
 
+// CSV import
+export const importCsv = async (file: File, table: string, token?: string) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('table', table);
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const response = await api.post('/import-csv', formData, { headers });
+  return response.data;
+};
+
 // Tenant endpoints
 export const updateTenant = async (
   tenantId: string,


### PR DESCRIPTION
## Summary
- add /import-csv API endpoint to load uploaded CSVs into BigQuery tables
- expose CSV import page and service to upload files from UI

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0933df9988323a7f1dfedb3d179ac