### PR TITLE
Handle BigQuery load errors

### DIFF
--- a/backend/tests/test_csv_importer.py
+++ b/backend/tests/test_csv_importer.py
@@ -1,9 +1,12 @@
 import os
 import sys
 import types
+import logging
 from pathlib import Path
 
+import pytest
 from google.cloud import bigquery
+from google.cloud.exceptions import GoogleCloudError
 
 # Ensure the backend directory is on the Python path so ``app`` can be imported
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -52,3 +55,56 @@ def test_load_csv_to_table(monkeypatch, tmp_path):
     assert job_config.write_disposition == bigquery.WriteDisposition.WRITE_TRUNCATE
     assert job_config.skip_leading_rows == 2
     assert recorded["quoted"] is False
+
+
+def test_load_csv_to_table_googleclouderror(monkeypatch, tmp_path, caplog):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("id\n1\n")
+
+    class DummyClient:
+        def load_table_from_file(self, file_obj, table, job_config):
+            raise GoogleCloudError("boom")
+
+    def fake_get_client():
+        return DummyClient()
+
+    def fake_get_settings():
+        return types.SimpleNamespace(PROJECT_ID="p", DATASET="d")
+
+    def fake_format_table(settings, table_name, quoted=False):
+        return f"{settings.PROJECT_ID}.{settings.DATASET}.{table_name}"
+
+    monkeypatch.setattr("app.services.csv_importer.get_client", fake_get_client)
+    monkeypatch.setattr("app.services.csv_importer.get_settings", fake_get_settings)
+    monkeypatch.setattr("app.services.csv_importer._format_table", fake_format_table)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(GoogleCloudError):
+            load_csv_to_table(str(csv_file), "Transactions")
+
+    assert "Failed to load CSV to table" in caplog.text
+
+
+def test_load_csv_to_table_file_not_found(monkeypatch, caplog):
+    class DummyClient:
+        def load_table_from_file(self, file_obj, table, job_config):  # pragma: no cover - should not call
+            raise AssertionError("load_table_from_file should not be called")
+
+    def fake_get_client():
+        return DummyClient()
+
+    def fake_get_settings():
+        return types.SimpleNamespace(PROJECT_ID="p", DATASET="d")
+
+    def fake_format_table(settings, table_name, quoted=False):
+        return f"{settings.PROJECT_ID}.{settings.DATASET}.{table_name}"
+
+    monkeypatch.setattr("app.services.csv_importer.get_client", fake_get_client)
+    monkeypatch.setattr("app.services.csv_importer.get_settings", fake_get_settings)
+    monkeypatch.setattr("app.services.csv_importer._format_table", fake_format_table)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(FileNotFoundError):
+            load_csv_to_table("missing.csv", "Transactions")
+
+    assert "Failed to load CSV to table" in caplog.text


### PR DESCRIPTION
## Summary
- log and re-raise BigQuery loading failures
- cover error scenarios in CSV importer tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0980b0a208323bf9ec8b659d9d3ba