### PR TITLE
Expose CSV import endpoint and page

### DIFF
--- a/backend/app/api/csv_import.py
+++ b/backend/app/api/csv_import.py
@@ -6,20 +6,20 @@ import os
 
 from app.services.csv_importer import load_csv_to_table
 
-router = APIRouter(prefix="/import-csv", tags=["csv"])
+router = APIRouter(tags=["csv"])
 
 
-@router.post("/", status_code=201)
+@router.post("/import-csv", status_code=201)
 async def import_csv(file: UploadFile = File(...), table: str = Form(...)):
     """Import a CSV file into a BigQuery table."""
-    tmp_path = None
+    tmp_path: str | None = None
     try:
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             shutil.copyfileobj(file.file, tmp)
             tmp_path = tmp.name
         await asyncio.to_thread(load_csv_to_table, tmp_path, table)
         return {"status": "success"}
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - error path
         raise HTTPException(status_code=500, detail=str(e))
     finally:
         file.file.close()

--- a/frontend/pages/import-csv.tsx
+++ b/frontend/pages/import-csv.tsx
@@ -23,8 +23,8 @@ export default function ImportCsvPage() {
     try {
       await importCsv(file, table, token ?? undefined);
       setSuccess('Importação realizada com sucesso.');
-    } catch (err) {
-      setError('Erro ao importar CSV.');
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Erro ao importar CSV.');
     } finally {
       setLoading(false);
     }

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -192,7 +192,9 @@ export const importCsv = async (file: File, table: string, token?: string) => {
   formData.append('file', file);
   formData.append('table', table);
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
-  const response = await api.post('/import-csv', formData, { headers });
+  const response = await api.post('/import-csv', formData, {
+    headers: { ...headers, 'Content-Type': 'multipart/form-data' },
+  });
   return response.data;
 };
 


### PR DESCRIPTION
## Summary
- add `/import-csv` FastAPI endpoint to trigger BigQuery CSV loading
- send multipart/form-data and auth headers via `importCsv` service
- show API error detail on import CSV page

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b099ed69208323a0a8533437959947