### PR TITLE
Handle BigQuery load errors gracefully

### DIFF
--- a/backend/app/services/csv_importer.py
+++ b/backend/app/services/csv_importer.py
@@ -10,7 +10,9 @@ from google.cloud.exceptions import GoogleCloudError
 from app.db.bq_client import get_client, get_settings, _format_table
 
 
-def load_csv_to_table(csv_path: str, table: str, *, skip_leading_rows: int = 1) -> None:
+def load_csv_to_table(
+    csv_path: str, table: str, *, skip_leading_rows: int = 1
+) -> str | None:
     """Load a CSV file into a BigQuery table truncating existing data.
 
     Args:
@@ -37,4 +39,6 @@ def load_csv_to_table(csv_path: str, table: str, *, skip_leading_rows: int = 1) 
             job.result()
     except (GoogleCloudError, FileNotFoundError) as exc:
         logging.error("Failed to load CSV to table %s: %s", table, exc)
-        raise
+        return f"Failed to load CSV to table {table}: {exc}"
+
+    return None

--- a/backend/tests/test_csv_importer.py
+++ b/backend/tests/test_csv_importer.py
@@ -4,7 +4,6 @@ import types
 import logging
 from pathlib import Path
 
-import pytest
 from google.cloud import bigquery
 from google.cloud.exceptions import GoogleCloudError
 
@@ -79,10 +78,10 @@ def test_load_csv_to_table_googleclouderror(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr("app.services.csv_importer._format_table", fake_format_table)
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(GoogleCloudError):
-            load_csv_to_table(str(csv_file), "Transactions")
+        msg = load_csv_to_table(str(csv_file), "Transactions")
 
     assert "Failed to load CSV to table" in caplog.text
+    assert "Failed to load CSV to table" in msg
 
 
 def test_load_csv_to_table_file_not_found(monkeypatch, caplog):
@@ -104,7 +103,7 @@ def test_load_csv_to_table_file_not_found(monkeypatch, caplog):
     monkeypatch.setattr("app.services.csv_importer._format_table", fake_format_table)
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(FileNotFoundError):
-            load_csv_to_table("missing.csv", "Transactions")
+        msg = load_csv_to_table("missing.csv", "Transactions")
 
     assert "Failed to load CSV to table" in caplog.text
+    assert "Failed to load CSV to table" in msg


### PR DESCRIPTION
## Summary
- return detailed message when BigQuery load fails
- test CSV importer failure scenarios without raising exceptions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b09c0fea0c8323a96823d891caef4a