### PR TITLE
test: ensure CLI imports each CSV

### DIFF
--- a/backend/tests/test_import_csv_cli.py
+++ b/backend/tests/test_import_csv_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -5,15 +6,18 @@ from pathlib import Path
 
 def test_cli_invokes_loader_for_each_csv(tmp_path):
     """Run the CLI and ensure each CSV file is passed to load_csv_to_table."""
-    calls_file = tmp_path / "calls.txt"
+    calls_file = tmp_path / "calls.json"
     sitecustomize = tmp_path / "sitecustomize.py"
     sitecustomize.write_text(
-        "import os\n"
+        "import os, json, atexit\n"
+        "from unittest.mock import MagicMock\n"
         "from app.services import csv_importer\n"
-        "def fake(path, table, skip_leading_rows=1):\n"
-        "    with open(os.environ['CALLS_FILE'], 'a', encoding='utf-8') as f:\n"
-        "        f.write(f'{path}|{table}|{skip_leading_rows}\\n')\n"
-        "csv_importer.load_csv_to_table = fake\n",
+        "mock = MagicMock()\n"
+        "csv_importer.load_csv_to_table = mock\n"
+        "def dump():\n"
+        "    with open(os.environ['CALLS_FILE'], 'w', encoding='utf-8') as f:\n"
+        "        json.dump([{'args': list(c.args), 'kwargs': c.kwargs} for c in mock.call_args_list], f)\n"
+        "atexit.register(dump)\n",
         encoding="utf-8",
     )
 
@@ -40,8 +44,14 @@ def test_cli_invokes_loader_for_each_csv(tmp_path):
         env=env,
     )
 
-    calls = calls_file.read_text(encoding="utf-8").strip().splitlines()
+    calls = json.loads(calls_file.read_text(encoding="utf-8"))
     assert calls == [
-        f"{csv1}|PlanOfAccounts|1",
-        f"{csv2}|PlanOfAccounts|1",
+        {
+            "args": [str(csv1), "PlanOfAccounts"],
+            "kwargs": {"skip_leading_rows": 1},
+        },
+        {
+            "args": [str(csv2), "PlanOfAccounts"],
+            "kwargs": {"skip_leading_rows": 1},
+        },
     ]


### PR DESCRIPTION
## Summary
- add test exercising import_csv CLI
- mock `load_csv_to_table` and verify calls for each CSV

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a039a3b88323839b719db93af2ae