### PR TITLE
Add robust CSV import error handling

### DIFF
--- a/backend/app/services/csv_importer.py
+++ b/backend/app/services/csv_importer.py
@@ -33,12 +33,16 @@ def load_csv_to_table(
 
     try:
         with open(csv_path, "rb") as csv_file:
-            job = client.load_table_from_file(
-                csv_file, table_ref, job_config=job_config
-            )
-            job.result()
-    except (GoogleCloudError, FileNotFoundError) as exc:
-        logging.error("Failed to load CSV to table %s: %s", table, exc)
-        return f"Failed to load CSV to table {table}: {exc}"
+            try:
+                job = client.load_table_from_file(
+                    csv_file, table_ref, job_config=job_config
+                )
+                job.result()
+            except GoogleCloudError as exc:
+                logging.error("Failed to load CSV to table %s: %s", table, exc)
+                return f"Failed to load CSV to table {table}: {exc}"
+    except FileNotFoundError as exc:
+        logging.error("CSV file %s not found: %s", csv_path, exc)
+        return f"CSV file {csv_path} not found: {exc}"
 
     return None

--- a/backend/tests/test_csv_importer.py
+++ b/backend/tests/test_csv_importer.py
@@ -80,8 +80,8 @@ def test_load_csv_to_table_googleclouderror(monkeypatch, tmp_path, caplog):
     with caplog.at_level(logging.ERROR):
         msg = load_csv_to_table(str(csv_file), "Transactions")
 
-    assert "Failed to load CSV to table" in caplog.text
-    assert "Failed to load CSV to table" in msg
+    assert "Failed to load CSV to table Transactions" in caplog.text
+    assert "Failed to load CSV to table Transactions" in msg
 
 
 def test_load_csv_to_table_file_not_found(monkeypatch, caplog):
@@ -105,5 +105,5 @@ def test_load_csv_to_table_file_not_found(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         msg = load_csv_to_table("missing.csv", "Transactions")
 
-    assert "Failed to load CSV to table" in caplog.text
-    assert "Failed to load CSV to table" in msg
+    assert "CSV file missing.csv not found" in caplog.text
+    assert "CSV file missing.csv not found" in msg


### PR DESCRIPTION
## Summary
- Wrap file open and BigQuery load operations in separate try/except blocks
- Log and return clear messages for missing files and load errors
- Extend tests to cover FileNotFoundError and GoogleCloudError scenarios

## Testing
- `cd backend && pytest tests/test_csv_importer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a15cf030832388a941b9b9d25201