### PR TITLE
Update QA report with new staging availability

### DIFF
--- a/docs/QA_SPRINT0_REPORT.md
+++ b/docs/QA_SPRINT0_REPORT.md
@@ -1,0 +1,66 @@
+# Relatório de QA – Sprint 0 (FinaFlow)
+
+## Contexto
+- **Objetivo:** validar integridade dos módulos dependentes de filtros, hierarquia contábil, token/BU e mapeamento financeiro.
+- **Abrangência:** Lançamentos Financeiros e Previstos, Fluxos de Caixa (Mensal e Diário), Caixa Físico, Investimentos, autenticação e troca de Business Unit.
+- **Ambiente:** Staging agora operacional com frontend `https://finaflow-lcz5.vercel.app/` e backend `https://finaflow-backend-staging-642830139828.us-central1.run.app`. Credenciais QA fornecidas: `qa@finaflow.test` / `QaFinaflow123!`. A reprovação anterior foi exclusivamente por indisponibilidade de ambiente e está sanada.
+
+## Resumo Executivo
+| Área | Resultado | Observações |
+| --- | --- | --- |
+| Filtros (todos os módulos) | 🚧 Não executado | Testes manuais pendentes; requere navegação UI. |
+| Hierarquia Contábil | 🚧 Não executado | Depende de sessão autenticada e comparação com planilha-modelo. |
+| Lançamentos (CRUD) | 🚧 Não executado | Aguardando execução manual (criar/editar/excluir previstos e realizados). |
+| Business Unit / Token | 🚧 Não executado | Troca de BU e validação de isolamento aguardam verificação manual. |
+| Caixa Físico e Investimentos | 🚧 Não executado | CRUD completo pendente em staging. |
+| Fluxo de Caixa (Mensal/Diário) | 🚧 Não executado | Necessário validar ordenação/totais após criação de lançamentos de teste. |
+| Regressão Sprint 0 | 🚧 Não executado | Login, navegação e dashboard precisam ser percorridos manualmente. |
+
+> Status geral da Sprint 0: **REPROVADA (testes funcionais não executados; evidências pendentes)**. Ambiente já está disponível; é necessário rodar integralmente o plano `SPRINT_0_QA_PLAN.md` para deliberar aprovação.
+
+## Evidências de Ambiente
+- `https://finaflow-lcz5.vercel.app/` responde 200 OK, confirmando que o frontend de staging está publicado.【6b6c32†L1-L17】
+- `https://finaflow-backend-staging-642830139828.us-central1.run.app` responde 200 OK para GET e 405 para HEAD, indicando serviço ativo em Cloud Run.【d222f0†L1-L4】【a47b76†L1-L9】 Credenciais QA disponíveis para autenticação via UI.
+
+## Detalhamento dos Testes (todos bloqueados)
+### 1. Filtros
+- Validar individualmente: `start_date`, `end_date`, `group_id`, `subgroup_id`, `account_id`, `transaction_type`, `status (previsto/realizado)`, `cost_center_id` (observação futura).
+- Validar combinações: grupo + conta; subgrupo + datas; conta + datas; grupo + subgrupo + datas; combinações arbitrárias.
+- Módulos: Lançamentos Financeiros, Lançamentos Previstos, Fluxo de Caixa Mensal, Fluxo de Caixa Diário.
+- **Status:** 🚧 Não executado – aguarda navegação UI e credenciais QA (agora disponíveis) para validar filtros isolados e combinados.
+
+### 2. Hierarquia Contábil
+- Verificar ordem grupos → subgrupos → contas, inclusão de contas faltantes e nomenclatura conforme planilha-modelo.
+- Conferir ordenação vertical e agrupamentos na UI.
+- **Status:** 🚧 Não executado – depende da UI e dados autenticados.
+
+### 3. Lançamentos
+- Criar, editar e remover lançamento com exibição imediata.
+- Filtragem por período e separação entre previsto vs realizado.
+- **Status:** 🚧 Não executado – falta execução manual com o usuário QA disponível.
+
+### 4. Business Unit (BU)
+- Trocar BU, validar isolamento de dados e atualização de token.
+- Garantir que lançamentos de BU distinta não apareçam após troca.
+- **Status:** 🚧 Não executado – precisa de navegação autenticada para observar token com `tenant_id` e `business_unit_id` e isolar dados.
+
+### 5. Caixa Físico e Investimentos
+- Criar, editar, listar, remover e validar persistência para ambos os módulos.
+- **Status:** 🚧 Não executado – depende de login QA para operar os CRUDs.
+
+### 6. Fluxo de Caixa
+- Mensal: validar ordenação, totais e agrupamento hierárquico.
+- Diário: validar ordenação, agrupamento e valores.
+- **Status:** 🚧 Não executado – requer geração de lançamentos de teste e comparação na UI.
+
+### 7. Regressão Sprint 0
+- Login, troca de BU, carregamento do dashboard, navegação geral e ausência de erros silenciosos.
+- **Status:** 🚧 Não executado – aguarda rodada completa de regressão agora que o ambiente está acessível.
+
+## Ações Recomendadas
+1. Percorrer o plano `SPRINT_0_QA_PLAN.md` executando os cenários de filtros, hierarquia, lançamentos (previstos e realizados), BU/token, caixa/investimentos e fluxos de caixa com o usuário QA.
+2. Registrar evidências (prints ou HAR) de cada cenário validado, incluindo token com `tenant_id` e `business_unit_id` após troca de BU.
+3. Atualizar este relatório com resultados por módulo (APROVADO/REPROVADO) e detalhamento de bugs encontrados, se houver.
+
+## Conclusão
+Sprint 0 segue **REPROVADA** por ausência de execução dos testes funcionais (não há evidências). A indisponibilidade de ambiente foi resolvida; é necessário rodar todo o plano de QA para deliberar aprovação.

--- a/docs/SPRINT_0_QA_PLAN.md
+++ b/docs/SPRINT_0_QA_PLAN.md
@@ -1,0 +1,84 @@
+# Plano de QA – Sprint 0 (FinaFlow)
+
+## 1) Contexto e Referências
+- **Objetivo:** validar a Sprint 0 baseada nas correções aplicadas no backend (commit de referência 8274db5) para filtros, hierarquia contábil, módulos de Caixa/Investimentos, token/BU e previsões.
+- **Documentos base:**
+  - `SPRINT_0_CORRECOES_APLICADAS.md` (escopo técnico das correções).
+  - `STAGING_SETUP.md`, `STAGING_DEPLOY_INSTRUCTIONS.md` e `scripts/create-staging.sh` (somente leitura para entender a arquitetura; execução bloqueada até liberação de permissões GCP/trivihair).
+- **Premissas:**
+  - URLs de backend (Cloud Run) e frontend (Vercel) de **staging** ainda não fornecidas.
+  - Nenhum teste funcional deve ser marcado como executado até as URLs e credenciais estarem disponíveis.
+
+## 2) Preparação (pré-staging)
+1. Revisar `SPRINT_0_CORRECOES_APLICADAS.md` para mapear endpoints e filtros corrigidos.
+2. Ler `STAGING_SETUP.md` e `STAGING_DEPLOY_INSTRUCTIONS.md` para compreender topologia, variáveis e comandos (não executar scripts de deploy no ambiente atual).
+3. Validar que os checklists abaixo estão prontos para execução assim que os endpoints de staging forem liberados.
+
+## 3) Escopo de Testes Funcionais (a executar quando o staging estiver disponível)
+
+### A. Filtros (Lançamentos Financeiros, Lançamentos Previstos, Fluxo de Caixa Mensal e Diário)
+**Cobertura obrigatória:**
+- Filtros isolados: `grupo`, `subgrupo`, `conta`, `data inicial`, `data final`, `tipo` (receita/despesa), `status` (previsto/realizado).
+- Combinações: `grupo + conta`; `subgrupo + datas`; `conta + datas`; `grupo + subgrupo + datas`; quaisquer combinações múltiplas.
+- Critérios: filtro não deve "grudar" em outro; resultados devem respeitar hierarquia e valores esperados; respostas sem erro 500.
+
+**Procedimento geral por módulo:**
+1. Autenticar e capturar token com `business_unit_id` válido.
+2. Aplicar cada filtro isoladamente e validar:
+   - Retorno HTTP 200.
+   - Lista não vazia quando dados existirem; vazia apenas quando filtro for realmente restritivo.
+   - Ordenação coerente com plano de contas quando aplicável.
+3. Repetir para combinações listadas acima.
+4. Registrar evidências (payloads e respostas) para cada cenário.
+
+### B. Hierarquia do Plano de Contas
+- Confirmar estrutura `grupo → subgrupo → conta` e ordenação por código.
+- Verificar inclusão de contas órfãs e nomenclatura conforme planilha-modelo.
+- Validar exibição na UI e no endpoint `/api/v1/chart-accounts/hierarchy`.
+- Evidenciar com captura/screenshot e amostra de resposta JSON.
+
+### C. Lançamentos (Previstos e Realizados)
+- Criar lançamento manual (previsto e realizado) e verificar exibição imediata.
+- Editar lançamento e confirmar atualização na listagem.
+- Remover e garantir remoção imediata da UI/endpoint.
+- Aplicar filtros por período e tipo (`transaction_type`, `status`).
+- Validar separação entre previsto vs realizado no endpoint `/cash-flow/previsto-realizado`.
+
+### D. Business Unit / Token
+- Autenticar, selecionar BU e confirmar que o token inclui `business_unit_id`.
+- Trocar de BU e verificar isolamento de dados (lancamentos, caixa, investimentos e fluxos não devem vazar entre BUs).
+- Reexecutar filtros após troca para garantir escopo correto.
+
+### E. Caixa Físico e Investimentos
+- Criar, editar, listar e remover registros em `/api/v1/caixa` e `/api/v1/investimentos`.
+- Checar persistência após refresh/relogin e ausência de erro 500.
+- Validar filtros de `tenant_id` e `business_unit_id` (dados devem ser restritos à BU ativa).
+
+### F. Fluxo de Caixa (Mensal e Diário)
+- Validar ordenação por grupo/subgrupo/conta.
+- Conferir totais e agrupamento hierárquico nos endpoints `/financial/cash-flow` (mensal) e `/cash-flow/daily` (diário).
+- Cross-check com lançamentos criados/fixtures conhecidos.
+
+### G. Regressão Sprint 0
+- Login (fluxo completo) e carregamento do dashboard inicial.
+- Navegação entre menus e ausência de erros silenciosos no console/network.
+- Troca de BU e revalidação de dados visíveis em cada módulo.
+
+## 4) Critérios de Aceite
+- Todos os filtros funcionam isolada e combinadamente em todos os módulos listados.
+- Hierarquia contábil correta e completa (sem contas ausentes ou órfãs não exibidas).
+- CRUD de lançamentos, caixa e investimentos persistem e respeitam `tenant_id`/`business_unit_id`.
+- Token/BU funcional em todo o fluxo, sem vazamento de dados entre BUs.
+- Fluxos de caixa (mensal/diário) com ordenação e totais alinhados aos lançamentos.
+- Regressão básica sem erros (login, dashboard, navegação).
+
+## 5) Evidências e Relatórios
+- Registrar requisições/respostas (payload + status) e capturas de tela onde aplicável.
+- Consolidar resultados no arquivo `SPRINT_0_QA_REPORT.md` com status **APROVADO** ou **REPROVADO**, listando cenários testados e defeitos (módulo, cenário, esperado, obtido, prioridade).
+- Caso o staging permaneça indisponível, documentar explicitamente: "Não testado: aguardando URL de STAGING" para cada bloco funcional.
+
+## 6) Checklist de Desbloqueio (Staging)
+- Receber URLs de backend (Cloud Run) e frontend (Vercel) de staging.
+- Obter credenciais/usuário de teste e confirmar escopos de `business_unit_id`.
+- Validar que os scripts de staging (`create-staging.sh`) não necessitam execução pelo QA; apenas leitura para compreensão.
+- Após desbloqueio, executar todas as seções A–G e atualizar `SPRINT_0_QA_REPORT.md` com os resultados.


### PR DESCRIPTION
## Summary
- update the Sprint 0 QA report with the new staging frontend/backend URLs and QA credentials
- document that the prior environment blocker is resolved while functional tests remain unexecuted and Sprint 0 stays reprovada pending evidence

## Testing
- curl -I https://finaflow-lcz5.vercel.app/
- curl -I https://finaflow-backend-staging-642830139828.us-central1.run.app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ecbae97188323a8a3c03354f82233)